### PR TITLE
keep screen on if screen flashlight is opened

### DIFF
--- a/app/src/main/res/layout/fragment_tool_screen_flashlight.xml
+++ b/app/src/main/res/layout/fragment_tool_screen_flashlight.xml
@@ -10,10 +10,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/white"
-        app:layout_constraintTop_toTopOf="parent"
+        android:keepScreenOn="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/off_btn"


### PR DESCRIPTION
Sorry for creating this pull request without asking and directly in main, but I think this is a bit like a bug. I don't know why Android Studio added the other layout_constraint attributes, but it should work with this too.