### PR TITLE
Sighting compass

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
@@ -6,8 +6,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.SeekBar
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
+import androidx.camera.core.CameraControl
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -88,6 +90,7 @@ class NavigatorFragment : Fragment() {
     private lateinit var destinationPanel: DestinationPanel
 
     private lateinit var cameraProviderFuture : ListenableFuture<ProcessCameraProvider>
+    private lateinit var cameraControl: CameraControl;
 
     private val beaconRepo by lazy { BeaconRepo.getInstance(requireContext()) }
     private val backtrackRepo by lazy { WaypointRepo.getInstance(requireContext()) }
@@ -156,8 +159,8 @@ class NavigatorFragment : Fragment() {
         preview.setSurfaceProvider(binding.viewCamera.surfaceProvider)
 
         var camera = cameraProvider.bindToLifecycle(this as LifecycleOwner, cameraSelector, preview)
-        val cameraControl = camera.getCameraControl()
-        cameraControl.setZoomRatio(2.toFloat())
+        cameraControl = camera.getCameraControl()
+        cameraControl.setZoomRatio(2.5f)
     }
 
     fun unbindPreview(cameraProvider : ProcessCameraProvider) {
@@ -234,6 +237,7 @@ class NavigatorFragment : Fragment() {
             if (binding.viewCamera.isVisible) {
                 binding.viewCameraLine.isVisible = false
                 binding.viewCamera.isVisible = false
+                binding.zoomRatioSeekbar.isVisible = false
                 if (userPrefs.navigation.rightQuickAction == QuickActionType.Flashlight) {
                     binding.navigationRightQuickAction.isClickable = true
                 }
@@ -250,6 +254,7 @@ class NavigatorFragment : Fragment() {
                 }, ContextCompat.getMainExecutor(requireContext()))
                 binding.viewCameraLine.isVisible = true
                 binding.viewCamera.isVisible = true
+                binding.zoomRatioSeekbar.isVisible = true
                 if (userPrefs.navigation.rightQuickAction == QuickActionType.Flashlight) {
                     binding.navigationRightQuickAction.isClickable = false
                 }
@@ -269,6 +274,16 @@ class NavigatorFragment : Fragment() {
         binding.viewCameraLine.setOnClickListener {
             toggleDestinationBearing()
         }
+
+        binding.zoomRatioSeekbar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                cameraControl.setZoomRatio(progress/2f+1)
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
+        })
 
         binding.beaconBtn.setOnClickListener {
             if (destination == null) {
@@ -640,6 +655,7 @@ class NavigatorFragment : Fragment() {
                 if (sightingCompassOpen) {
                     binding.viewCamera.visibility = View.VISIBLE
                     binding.viewCameraLine.visibility = View.VISIBLE
+                    binding.zoomRatioSeekbar.visibility = View.VISIBLE
                 }
             }
             binding.roundCompass.visibility = View.INVISIBLE
@@ -649,6 +665,7 @@ class NavigatorFragment : Fragment() {
             binding.navigationOpenArCamera.visibility = View.INVISIBLE
             binding.viewCamera.visibility = View.INVISIBLE
             binding.viewCameraLine.visibility = View.INVISIBLE
+            binding.zoomRatioSeekbar.visibility = View.INVISIBLE
             binding.roundCompass.visibility = if (userPrefs.navigation.useRadarCompass) View.INVISIBLE else View.VISIBLE
             binding.radarCompass.visibility = if (userPrefs.navigation.useRadarCompass) View.VISIBLE else View.INVISIBLE
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.*
 import java.util.*
+import kotlin.math.roundToInt
 
 
 class NavigatorFragment : Fragment() {
@@ -145,6 +146,12 @@ class NavigatorFragment : Fragment() {
         )
         if (userPrefs.experimentalEnabled) {
             cameraProviderFuture = ProcessCameraProvider.getInstance(requireContext())
+            var zoomRatio = cache.getFloat("camera_zoom_ratio")
+            if (zoomRatio == null) {
+                zoomRatio = 2.5f
+                cache.putFloat("camera_zoom_ratio", zoomRatio)
+            }
+            binding.zoomRatioSeekbar.progress = ((zoomRatio-1)*2).roundToInt()
         }
         return binding.root
     }
@@ -161,7 +168,12 @@ class NavigatorFragment : Fragment() {
 
         var camera = cameraProvider.bindToLifecycle(this as LifecycleOwner, cameraSelector, preview)
         cameraControl = camera.getCameraControl()
-        cameraControl.setZoomRatio(2.5f)
+        var zoomRatio = cache.getFloat("camera_zoom_ratio")
+        if (zoomRatio == null) {
+            zoomRatio = 2.5f
+            cache.putFloat("camera_zoom_ratio", zoomRatio)
+        }
+        cameraControl.setZoomRatio(zoomRatio)
     }
 
     fun unbindPreview(cameraProvider : ProcessCameraProvider) {
@@ -279,6 +291,7 @@ class NavigatorFragment : Fragment() {
         binding.zoomRatioSeekbar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 cameraControl.setZoomRatio(progress/2f+1)
+                cache.putFloat("camera_zoom_ratio", progress/2f+1)
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar?) {}

--- a/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/NavigatorFragment.kt
@@ -69,7 +69,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.*
 import java.util.*
-import kotlin.math.roundToInt
 
 
 class NavigatorFragment : Fragment() {
@@ -151,7 +150,7 @@ class NavigatorFragment : Fragment() {
                 zoomRatio = 2.5f
                 cache.putFloat("camera_zoom_ratio", zoomRatio)
             }
-            binding.zoomRatioSeekbar.progress = ((zoomRatio-1)*2).roundToInt()
+            binding.zoomRatioSeekbar.progress = ((zoomRatio-1)*2).toInt()
         }
         return binding.root
     }

--- a/app/src/main/res/layout/activity_navigator.xml
+++ b/app/src/main/res/layout/activity_navigator.xml
@@ -382,4 +382,18 @@
         </LinearLayout>
     </LinearLayout>
 
+    <SeekBar
+        android:id="@+id/zoom_ratio_seekbar"
+        android:layout_width="250dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:max="6"
+        android:progress="3"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/view_camera" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The user can now change the zoom ratio with a SeekBar below the camera view. This should resolve the last problems on the scaled/cropped image, right? 
And I fixed a bug, the camera would ran in the background if you leave the linear compass view (with the camera view enabled).