### PR TITLE
Allow refreshing clock

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
@@ -41,6 +41,11 @@ class ToolClockFragment : Fragment() {
         binding.pipButton.setOnClickListener {
             sendNextMinuteNotification()
         }
+        binding.clockRefresh.setOnClickListener {
+            gps.start(this::onGPSUpdate)
+            binding.updatingClock.visibility = View.VISIBLE
+            binding.pipButton.visibility = View.INVISIBLE
+        }
         return binding.root
     }
 

--- a/app/src/main/res/layout/fragment_tool_clock.xml
+++ b/app/src/main/res/layout/fragment_tool_clock.xml
@@ -5,6 +5,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/clock_refresh"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:tint="?android:textColorSecondary"
+        app:backgroundTint="?android:colorBackgroundFloating"
+        app:fabSize="mini"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:rippleColor="@color/colorPrimary"
+        app:srcCompat="@drawable/ic_update" />
+
     <TextView
         android:id="@+id/clock"
         android:layout_width="wrap_content"


### PR DESCRIPTION
The button looks like a quick action, but I wasn't able to test it, my device says always if I want to test it that there's no GPS signal. (But it does nothing than the same as the onResume() method)
And I think, the UTC time is unnecessary if the phone is already in UTC timezone - I would hide it if it's the same, but I don't know if there are any advantages on a separate UTC time textView.