### PR TITLE
Hide UTC time if phone is already in UTC timezone

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
@@ -85,10 +85,16 @@ class ToolClockFragment : Fragment() {
     private fun update() {
         val systemDiff = Duration.between(systemTime, Instant.now())
         val currentTime = gpsTime.plus(systemDiff)
-        val utcTime = ZonedDateTime.ofInstant(currentTime, ZoneId.of("UTC"))
         val myTime = ZonedDateTime.ofInstant(currentTime, ZoneId.systemDefault())
-        binding.utcClock.text =
-            getString(R.string.utc_format, formatService.formatTime(utcTime.toLocalTime()))
+        if (ZoneId.systemDefault() == ZoneId.of("GMT")) {
+            binding.utcClock.visibility = View.INVISIBLE
+        }
+        else {
+            binding.utcClock.visibility = View.VISIBLE
+            val utcTime = ZonedDateTime.ofInstant(currentTime, ZoneId.of("UTC"))
+            binding.utcClock.text =
+                getString(R.string.utc_format, formatService.formatTime(utcTime.toLocalTime()))
+        }
         binding.clock.text = formatService.formatTime(myTime.toLocalTime())
         binding.date.text = formatService.formatDate(myTime)
         binding.analogClock.time = myTime.toLocalTime()


### PR DESCRIPTION
If the phone is in UTC time, the timezone returned by the ZoneId.systemDefault() is "GMT", but it's the same (even if "GMT" is the outdated as name).