### PR TITLE
Fix typo in German REAME

### DIFF
--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -15,4 +15,4 @@
 <h4>Berechtigungen</h4>
 <p>Standort (genau, Hintergrund): Wird für Wegpunktnavigation, das Herausfinden der Richtung zum geographischen Norden, Höhenkorrigierung beim Höhenmessen (im Hintergrund) und Auf-/Untergangszeiten für Sonne/Mond verwendet.</p>
 <p>Taschenlampe: Wird für Taschenlampen-Funktion im Navigations-Tab verwendet.</p>
-<p>Körerliche Aktivität: Wird im Schrittzähler-basierten Kilometerzähler verwendet, um die Distanz herauszufinden.</p>
+<p>Körperliche Aktivität: Wird im Schrittzähler-basierten Kilometerzähler verwendet, um die Distanz herauszufinden.</p>

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,5 +1,5 @@
 <h4>Navigation</h4>
-<p>Der Kompass kann verwendet werden, um die Richtung nach Norden herauszufindenund wenn er mit GPS kombiniert wird, ist auch eine Navigation zu vorher festgelegten Orten möglich. Diese vorher festgelegten Orte, die Wegpunkte, können an Ihrem Standort oder auch an jedem anderen Punkt erstellt werden, sodass Sie zurück navigieren können, wenn Sie einen Wegpunkt gesetzt haben.</p>
+<p>Der Kompass kann verwendet werden, um die Richtung nach Norden herauszufinden und wenn er mit GPS kombiniert wird, ist auch eine Navigation zu vorher festgelegten Orten möglich. Diese vorher festgelegten Orte, die Wegpunkte, können an Ihrem Standort oder auch an jedem anderen Punkt erstellt werden, sodass Sie zurück navigieren können, wenn Sie einen Wegpunkt gesetzt haben.</p>
 <p>Beipiel-Wegpunkte: Campingplatz, Arbeit, Wegweiser</p>
 <p>Die Taschenlampe kann einfach vom Navigations-Tab aus aktiviert werden (normaler/SOS-Modus)</p>
 


### PR DESCRIPTION
I found two typos in my README translation, here's the fix for it.