### PR TITLE
Error Bar: Increase Padding of Close Button

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/LinearCompassView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/navigation/ui/LinearCompassView.kt
@@ -150,7 +150,7 @@ class LinearCompassView : CanvasView, ICompassView {
                             else -> ""
                         }
                         noStroke()
-                        fill(Resources.androidTextColorPrimary(context))
+                        fill(Resources.color(context, R.color.colorPrimary))
                         textMode(TextMode.Corner)
                         text(coord, pixDeg * (i - minDegrees), 5 / 12f * height)
                     }

--- a/app/src/main/res/layout/view_error_banner.xml
+++ b/app/src/main/res/layout/view_error_banner.xml
@@ -40,16 +40,16 @@
         android:id="@+id/error_action"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
+        android:layout_marginEnd="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/error_close"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/error_close"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
-        android:layout_marginEnd="12dp"
+        android:layout_width="48dp"
+        android:layout_height="46dp"
+        android:layout_marginEnd="6dp"
         android:background="@android:color/transparent"
         android:tint="@color/black"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
The close button of the error bar is a bit difficult to hit. This PR just increases the padding, so the area around the button is also clickable. This doesn't affect the visible size of the button.