### PR TITLE
Add roundness to dialogs

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
+        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
     </style>
 
     <style name="AppBottomSheetDialogTheme" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
@@ -13,6 +14,10 @@
     <style name="AppBottomSheetModalStyle" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@drawable/rounded_bottom_dialog</item>
         <item name="android:padding">16dp</item>
+    </style>
+
+    <style name="AlertDialogTheme" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+        <item name="dialogCornerRadius">16dp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Somehow feels more natural as the newer Android versions do the same about their system dialogs.

<img width="352" alt="image" src="https://user-images.githubusercontent.com/833473/134828282-9cad9379-e9a8-48a0-b358-21131495492e.png">
