### PR TITLE
Use Material base styles instead appcompat

### DIFF
--- a/app/src/main/res/drawable/rounded_bottom_dialog.xml
+++ b/app/src/main/res/drawable/rounded_bottom_dialog.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?android:colorBackgroundFloating" />
-    <corners
-        android:topLeftRadius="16dp"
-        android:topRightRadius="16dp" />
-
-</shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
@@ -16,7 +16,7 @@
         <item name="android:padding">16dp</item>
     </style>
 
-    <style name="AlertDialogTheme" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+    <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
         <item name="dialogCornerRadius">16dp</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -12,9 +12,15 @@
         <item name="bottomSheetStyle">@style/AppBottomSheetModalStyle</item>
     </style>
 
-    <style name="AppBottomSheetModalStyle" parent="Widget.Design.BottomSheet.Modal">
-        <item name="android:background">@drawable/rounded_bottom_dialog</item>
+    <style name="AppBottomSheetModalStyle" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="shapeAppearance">@style/AppBottomSheetAppearance</item>
         <item name="android:padding">16dp</item>
+    </style>
+
+    <style name="AppBottomSheetAppearance">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopLeft">16dp</item>
+        <item name="cornerSizeTopRight">16dp</item>
     </style>
 
     <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
+        <item name="materialButtonStyle">@style/ButtonTheme</item>
     </style>
 
     <style name="AppBottomSheetDialogTheme" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
@@ -18,6 +19,15 @@
 
     <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
         <item name="dialogCornerRadius">16dp</item>
+    </style>
+
+    <style name="ButtonTheme" parent="Widget.MaterialComponents.Button">
+        <item name="shapeAppearanceOverlay">@style/ButtonAppearance</item>
+    </style>
+
+    <style name="ButtonAppearance">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Turns the old looking buttons of

<img width="301" alt="image" src="https://user-images.githubusercontent.com/833473/134859476-f4818365-22e4-4781-86a0-b10b29bf77b9.png">

<img width="293" alt="image" src="https://user-images.githubusercontent.com/833473/134860234-bc513e50-c778-470e-bc8d-99745095c46a.png">

into 

<img width="298" alt="image" src="https://user-images.githubusercontent.com/833473/134859568-1b6a458f-84c5-4428-b556-bd1055b534ba.png">

<img width="299" alt="image" src="https://user-images.githubusercontent.com/833473/134859729-6f4d9f4c-9486-476d-8f1e-f3b3c6e466f1.png">


