### PR TITLE
Set default text color of app's buttons

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,6 +29,7 @@
 
     <style name="ButtonTheme" parent="Widget.MaterialComponents.Button">
         <item name="shapeAppearanceOverlay">@style/ButtonAppearance</item>
+        <item name="android:textColor">@color/white</item>
     </style>
 
     <style name="ButtonAppearance">


### PR DESCRIPTION
Fixes " Text on primary color buttons should be the same (probably white - I'll check the contract score first)" of #940 AFAICT

<img width="241" alt="image" src="https://user-images.githubusercontent.com/833473/135038148-799699d8-c075-495b-9f44-75f2efb665b6.png">