### PR TITLE
Fix light theme status bar color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,7 @@
 <resources>
 
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">#90000000</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>


### PR DESCRIPTION
Fixes "Light theme causes system top bar to become blue" of #940

<img width="246" alt="image" src="https://user-images.githubusercontent.com/833473/135040110-5860e5a6-477d-4cbf-bb27-92ee0f9dbea5.png">

vs before my material changes,

<img width="246" alt="image" src="https://user-images.githubusercontent.com/833473/135039220-9060f1a7-f34f-4afd-8e6c-7aeec4186816.png">
