### PR TITLE
Improvement - Compact Mode

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView
 import com.kylecorry.andromeda.core.system.GeoUri
+import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.andromeda.core.system.Screen
 import com.kylecorry.andromeda.core.tryOrNothing
 import com.kylecorry.andromeda.fragments.AndromedaActivity
@@ -30,7 +31,6 @@ import com.kylecorry.trail_sense.main.errors.ExceptionHandler
 import com.kylecorry.trail_sense.onboarding.OnboardingActivity
 import com.kylecorry.trail_sense.receivers.RestartServicesCommand
 import com.kylecorry.trail_sense.settings.ui.SettingsMoveNotice
-import com.kylecorry.trail_sense.shared.CustomUiUtils.dpToPx
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils.setupWithNavController
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.commands.ComposedCommand
@@ -93,7 +93,7 @@ class MainActivity : AndromedaActivity() {
 
         navController = findNavController()
         bottomNavigation = findViewById(R.id.bottom_navigation)
-        setBottomNavLabelVisibility()
+        setBottomNavLabelsVisibility()
         bottomNavigation.setupWithNavController(navController, false)
 
         if (userPrefs.theme == UserPreferences.Theme.Black || userPrefs.theme == UserPreferences.Theme.Night) {
@@ -112,15 +112,15 @@ class MainActivity : AndromedaActivity() {
         }
     }
 
-    fun changeBottomNavLabelVisibility(useCompactMode: Boolean){
-        cache.putBoolean("pref_use_compact_mode", useCompactMode)
-        recreate()
+    fun changeBottomNavLabelsVisibility(useCompactMode: Boolean){
+        userPrefs.useCompactMode = useCompactMode
+        setBottomNavLabelsVisibility()
     }
 
-    private fun setBottomNavLabelVisibility(){
+    private fun setBottomNavLabelsVisibility(){
         if(userPrefs.useCompactMode) {
             bottomNavigation.apply {
-                layoutParams.height = 55.dpToPx()
+                layoutParams.height = Resources.dp(context, 55f).toInt()
                 labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_UNLABELED
             }
         } else {

--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -11,10 +11,12 @@ import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MenuItem
+import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import com.kylecorry.andromeda.core.system.GeoUri
 import com.kylecorry.andromeda.core.system.Screen
 import com.kylecorry.andromeda.core.tryOrNothing
@@ -28,6 +30,7 @@ import com.kylecorry.trail_sense.main.errors.ExceptionHandler
 import com.kylecorry.trail_sense.onboarding.OnboardingActivity
 import com.kylecorry.trail_sense.receivers.RestartServicesCommand
 import com.kylecorry.trail_sense.settings.ui.SettingsMoveNotice
+import com.kylecorry.trail_sense.shared.CustomUiUtils.dpToPx
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils.setupWithNavController
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.commands.ComposedCommand
@@ -90,6 +93,7 @@ class MainActivity : AndromedaActivity() {
 
         navController = findNavController()
         bottomNavigation = findViewById(R.id.bottom_navigation)
+        setBottomNavLabelVisibility()
         bottomNavigation.setupWithNavController(navController, false)
 
         if (userPrefs.theme == UserPreferences.Theme.Black || userPrefs.theme == UserPreferences.Theme.Night) {
@@ -105,6 +109,25 @@ class MainActivity : AndromedaActivity() {
 
         requestPermissions(permissions) {
             startApp()
+        }
+    }
+
+    fun changeBottomNavLabelVisibility(useCompactMode: Boolean){
+        cache.putBoolean("pref_use_compact_mode", useCompactMode)
+        recreate()
+    }
+
+    private fun setBottomNavLabelVisibility(){
+        if(userPrefs.useCompactMode) {
+            bottomNavigation.apply {
+                layoutParams.height = 55.dpToPx()
+                labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_UNLABELED
+            }
+        } else {
+            bottomNavigation.apply {
+                layoutParams.height = LayoutParams.WRAP_CONTENT
+                labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_AUTO
+            }
         }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
@@ -77,6 +77,13 @@ class SettingsFragment : AndromedaPreferenceFragment() {
             true
         }
 
+        //Set Compact Mode
+        val compactMode = switch(R.string.pref_use_compact_mode)
+        compactMode?.setOnPreferenceChangeListener { _, checked ->
+            requireMainActivity().changeBottomNavLabelVisibility(checked as Boolean)
+            true
+        }
+
         val version = Package.getVersionName(requireContext())
         preference(R.string.pref_app_version)?.summary = version
         setIconColor(preferenceScreen, Resources.androidTextColorSecondary(requireContext()))

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
@@ -80,7 +80,7 @@ class SettingsFragment : AndromedaPreferenceFragment() {
         //Set Compact Mode
         val compactMode = switch(R.string.pref_use_compact_mode)
         compactMode?.setOnPreferenceChangeListener { _, checked ->
-            requireMainActivity().changeBottomNavLabelVisibility(checked as Boolean)
+            requireMainActivity().changeBottomNavLabelsVisibility(checked as Boolean)
             true
         }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
@@ -459,4 +459,9 @@ object CustomUiUtils {
         }
     }
 
+    /**
+     * Int extension to convert dp to px based on device pixel density
+     */
+    fun Int.dpToPx(): Int = (this * android.content.res.Resources.getSystem().displayMetrics.density).toInt()
+
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
@@ -459,9 +459,4 @@ object CustomUiUtils {
         }
     }
 
-    /**
-     * Int extension to convert dp to px based on device pixel density
-     */
-    fun Int.dpToPx(): Int = (this * android.content.res.Resources.getSystem().displayMetrics.density).toInt()
-
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
@@ -199,7 +199,7 @@ class UserPreferences(private val context: Context) : IDeclinationPreferences {
         false
     )
 
-    val useCompactMode by BooleanPreference(
+    var useCompactMode by BooleanPreference(
         cache,
         context.getString(R.string.pref_use_compact_mode),
         false

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
@@ -199,6 +199,12 @@ class UserPreferences(private val context: Context) : IDeclinationPreferences {
         false
     )
 
+    val useCompactMode by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_use_compact_mode),
+        false
+    )
+
     // Calibration
 
     override var useAutoDeclination: Boolean

--- a/app/src/main/res/drawable/page_layout_footer.xml
+++ b/app/src/main/res/drawable/page_layout_footer.xml
@@ -1,0 +1,8 @@
+<!-- drawable/page_layout_footer.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#ffffff" android:pathData="M6,2H18A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2M6,16V20H18V16H6Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1320,7 +1320,9 @@
     <string name="clinometer_augmented_reality_description">Visualize angles with your camera</string>
     <string name="pref_use_dynamic_colors" translatable="false">pref_use_dynamic_colors</string>
     <string name="dynamic_colors">Dynamic Colors</string>
+    <string name="compact_mode">Compact Mode</string>
     <string name="pref_use_dynamic_colors_on_compass" translatable="false">pref_use_dynamic_colors_on_compass</string>
+    <string name="pref_use_compact_mode" translatable="false">pref_use_compact_mode</string>
     <string name="compass_dynamic_colors">Compass Dynamic Colors</string>
     <string name="compass_dynamic_colors_summary">Use Dynamic Colors for cardinal directions</string>
     <string name="screen_flashlight_full_name">Screen Flashlight</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -73,6 +73,12 @@
             app:key="@string/pref_use_dynamic_colors_on_compass"
             app:singleLineTitle="false"
             app:title="@string/compass_dynamic_colors" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:icon="@drawable/page_layout_footer"
+            app:key="pref_use_compact_mode"
+            app:singleLineTitle="false"
+            app:title="@string/compact_mode" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
The following PR includes the functionality requested in issue [#1748](https://github.com/kylecorry31/Trail-Sense/issues/1748).

### Implementation description:
What has been done is to add the compact mode toggle within the settings page, `page_layout_footer` icon has been integrated (vector resource downloaded from: https://pictogrammers.com/library/mdi/icon/page-layout-footer/ ).
`changeBottomNavLabelVisibility` method has been introduced in the `MainActivity` to allow the compact mode setting desired by the user to be saved in persistence (by default set to false).
The value is retrieved from the SharedPreferences via the variable `useCompactMode` of the `UserPreferences` class.
In the `MainActivity` at `onCreate()` the `setBottomNavLabelVisibility()` method is called, which will customise the bottom navigation bar according to the compact mode value set by the user.
An extension function has also been added to the Integer class to allow the calculation of dp to px based on device pixel density.


A short video of the functionality:

https://github.com/kylecorry31/Trail-Sense/assets/34175360/4ea57ca5-0056-42a4-9e83-1c93015d189e

