### PR TITLE
Improverment - Statusbar background color based on theme

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -13,6 +13,7 @@ import android.view.KeyEvent
 import android.view.MenuItem
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.core.os.bundleOf
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -31,6 +32,7 @@ import com.kylecorry.trail_sense.main.errors.ExceptionHandler
 import com.kylecorry.trail_sense.onboarding.OnboardingActivity
 import com.kylecorry.trail_sense.receivers.RestartServicesCommand
 import com.kylecorry.trail_sense.settings.ui.SettingsMoveNotice
+import com.kylecorry.trail_sense.shared.CustomUiUtils.isDarkThemeOn
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils.setupWithNavController
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.commands.ComposedCommand
@@ -46,6 +48,7 @@ import com.kylecorry.trail_sense.tools.whitenoise.infrastructure.WhiteNoiseServi
 import com.kylecorry.trail_sense.tools.clinometer.volumeactions.ClinometerLockVolumeAction
 import com.kylecorry.trail_sense.tools.flashlight.volumeactions.FlashlightToggleVolumeAction
 import com.kylecorry.trail_sense.shared.VolumeAction
+import com.kylecorry.trail_sense.shared.colors.ColorUtils
 
 
 class MainActivity : AndromedaActivity() {
@@ -96,10 +99,7 @@ class MainActivity : AndromedaActivity() {
         setBottomNavLabelsVisibility()
         bottomNavigation.setupWithNavController(navController, false)
 
-        if (userPrefs.theme == UserPreferences.Theme.Black || userPrefs.theme == UserPreferences.Theme.Night) {
-            window.decorView.rootView.setBackgroundColor(Color.BLACK)
-            bottomNavigation.setBackgroundColor(Color.BLACK)
-        }
+        setBarsColorBasedOnCurrentTheme(userPrefs.theme)
 
         if (cache.getBoolean(getString(R.string.pref_onboarding_completed)) != true) {
             startActivity(Intent(this, OnboardingActivity::class.java))
@@ -127,6 +127,40 @@ class MainActivity : AndromedaActivity() {
             bottomNavigation.apply {
                 layoutParams.height = LayoutParams.WRAP_CONTENT
                 labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_AUTO
+            }
+        }
+    }
+
+    /**
+     * Setup Statusbar and Bottom Nav color based on theme selected
+     */
+    private fun setBarsColorBasedOnCurrentTheme(theme: UserPreferences.Theme){
+        when(theme){
+            UserPreferences.Theme.Black, UserPreferences.Theme.Night -> {
+                window.apply {
+                    statusBarColor = Color.BLACK
+                    decorView.rootView.setBackgroundColor(Color.BLACK)
+                }
+                bottomNavigation.setBackgroundColor(Color.BLACK)
+            }
+            UserPreferences.Theme.Dark -> {
+                window.statusBarColor = ColorUtils.backgroundColor(window.decorView.rootView.context)
+            }
+            UserPreferences.Theme.Light -> {
+                window.statusBarColor = ColorUtils.backgroundColor(window.decorView.rootView.context)
+                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
+            }
+            UserPreferences.Theme.System -> {
+                if(isDarkThemeOn())
+                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Dark)
+                else
+                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Light)
+            }
+            UserPreferences.Theme.SunriseSunset -> {
+                if(sunriseSunsetTheme() == ColorTheme.Dark)
+                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Dark)
+                else
+                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Light)
             }
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : AndromedaActivity() {
         setBottomNavLabelsVisibility()
         bottomNavigation.setupWithNavController(navController, false)
 
-        setBarsColorBasedOnCurrentTheme(userPrefs.theme)
+        setBarsColorBasedOnCurrentTheme()
 
         if (cache.getBoolean(getString(R.string.pref_onboarding_completed)) != true) {
             startActivity(Intent(this, OnboardingActivity::class.java))
@@ -134,33 +134,17 @@ class MainActivity : AndromedaActivity() {
     /**
      * Setup Statusbar and Bottom Nav color based on theme selected
      */
-    private fun setBarsColorBasedOnCurrentTheme(theme: UserPreferences.Theme){
-        when(theme){
-            UserPreferences.Theme.Black, UserPreferences.Theme.Night -> {
-                window.apply {
-                    statusBarColor = Color.BLACK
-                    decorView.rootView.setBackgroundColor(Color.BLACK)
-                }
-                bottomNavigation.setBackgroundColor(Color.BLACK)
+    private fun setBarsColorBasedOnCurrentTheme(){
+        if(userPrefs.theme == UserPreferences.Theme.Black || userPrefs.theme == UserPreferences.Theme.Night){
+            window.apply {
+                statusBarColor = Color.BLACK
+                decorView.rootView.setBackgroundColor(Color.BLACK)
             }
-            UserPreferences.Theme.Dark -> {
-                window.statusBarColor = ColorUtils.backgroundColor(window.decorView.rootView.context)
-            }
-            UserPreferences.Theme.Light -> {
-                window.statusBarColor = ColorUtils.backgroundColor(window.decorView.rootView.context)
+            bottomNavigation.setBackgroundColor(Color.BLACK)
+        }else{
+            window.statusBarColor = ColorUtils.backgroundColor(window.decorView.rootView.context)
+            if(!isDarkThemeOn()){
                 WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
-            }
-            UserPreferences.Theme.System -> {
-                if(isDarkThemeOn())
-                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Dark)
-                else
-                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Light)
-            }
-            UserPreferences.Theme.SunriseSunset -> {
-                if(sunriseSunsetTheme() == ColorTheme.Dark)
-                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Dark)
-                else
-                    setBarsColorBasedOnCurrentTheme(UserPreferences.Theme.Light)
             }
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/CustomUiUtils.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.shared
 
 import android.content.Context
+import android.content.res.Configuration
 import android.net.Uri
 import android.util.Size
 import android.view.View
@@ -457,6 +458,11 @@ object CustomUiUtils {
         } else {
             AppColor.Orange.color
         }
+    }
+
+    fun Context.isDarkThemeOn(): Boolean {
+        return resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
     }
 
 }


### PR DESCRIPTION
The following PR includes the functionality requested in issue https://github.com/kylecorry31/Trail-Sense/issues/1665.

### Implementation description:
I have created the `methodosetBarsColourBasedOnCurrentTheme` which takes the `UserPreferences.Theme` as input and assigns the corresponding appearance to the stasubar and navbar.
Note that the `UserPreferences.Theme` was passed as input so that in the `Theme.System` and `Theme.Sunrise` cases the same method can be recursively called while keeping the code clean.

Result:

https://github.com/kylecorry31/Trail-Sense/assets/34175360/543a0295-cca7-49ab-ae7e-7ad89240b3e9

