### PR TITLE
Improvement - Flip Camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build-cache/
 /app/nightly/
 release-builds-helper.sh
 .idea/appInsightsSettings.xml
+.idea/shelf

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
     implementation("com.google.android.flexbox:flexbox:3.0.0")
 
     // Andromeda
-    val andromedaVersion = "819c64764e"
+    val andromedaVersion = "6e071b6b3a"
     implementation("com.github.kylecorry31.andromeda:core:$andromedaVersion")
     implementation("com.github.kylecorry31.andromeda:fragments:$andromedaVersion")
     implementation("com.github.kylecorry31.andromeda:forms:$andromedaVersion")

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/views/CameraView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/views/CameraView.kt
@@ -8,6 +8,7 @@ import android.util.Size
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
+import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.SeekBar
@@ -43,6 +44,7 @@ class CameraView(context: Context, attrs: AttributeSet?) : FrameLayout(context, 
 
     private val preview: PreviewView
     private val torchBtn: ImageButton
+    private val changeCameraBtn: ImageButton
     private val zoomSeek: SeekBar
     private var zoomListener: ((Float) -> Unit)? = null
     private var imageListener: ((Bitmap) -> Unit)? = null
@@ -210,15 +212,27 @@ class CameraView(context: Context, attrs: AttributeSet?) : FrameLayout(context, 
         preview = findViewById(R.id.camera_preview)
         torchBtn = findViewById(R.id.camera_torch)
         zoomSeek = findViewById(R.id.camera_zoom)
+        changeCameraBtn = findViewById(R.id.camera_change)
+
+        val a = context.obtainStyledAttributes(attrs, R.styleable.CameraView, 0, 0)
 
         torchBtn.setOnClickListener {
             setTorch(!isTorchOn)
+        }
+
+        if(a.getBoolean(R.styleable.CameraView_flipEnable,false)) {
+            changeCameraBtn.visibility = View.VISIBLE
+            changeCameraBtn.setOnClickListener {
+                camera?.flipCamera()
+            }
         }
 
         zoomSeek.setOnProgressChangeListener { progress, _ ->
             zoomListener?.invoke(progress / 100f)
             setZoom(progress / 100f)
         }
+
+        a.recycle()
     }
 
     private val mGestureListener = object : GestureDetector.SimpleOnGestureListener() {

--- a/app/src/main/res/drawable/camera_flip.xml
+++ b/app/src/main/res/drawable/camera_flip.xml
@@ -1,0 +1,9 @@
+<!-- drawable/camera_flip.xml -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#ffffff" android:pathData="M20 5H17L15 3H9L7 5H4C2.9 5 2 5.9 2 7V19C2 20.11 2.9 21 4 21H20C21.11 21 22 20.11 22 19V7C22 5.9 21.11 5 20 5M5 12H7.1C7.65 9.29 10.29 7.55 13 8.1C13.76 8.25 14.43 8.59 15 9L13.56 10.45C13.11 10.17 12.58 10 12 10C10.74 10 9.6 10.8 9.18 12H11L8 15L5 12M16.91 14C16.36 16.71 13.72 18.45 11 17.9C10.25 17.74 9.58 17.41 9 17L10.44 15.55C10.9 15.83 11.43 16 12 16C13.27 16 14.41 15.2 14.83 14H13L16 11L19 14H16.91Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_photo_import_sheet.xml
+++ b/app/src/main/res/layout/fragment_photo_import_sheet.xml
@@ -18,7 +18,8 @@
         android:id="@+id/camera"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        app:flipEnable="true" />
 
     <FrameLayout
         android:layout_width="64dp"

--- a/app/src/main/res/layout/fragment_qr_import_sheet.xml
+++ b/app/src/main/res/layout/fragment_qr_import_sheet.xml
@@ -21,6 +21,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@drawable/rounded_rectangle"
+        app:flipEnable="true"
         app:layout_constraintDimensionRatio="H,1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_scan_text.xml
+++ b/app/src/main/res/layout/fragment_scan_text.xml
@@ -13,6 +13,7 @@
         android:layout_gravity="center_horizontal"
         android:layout_margin="16dp"
         android:background="@drawable/rounded_rectangle"
+        app:flipEnable="true"
         app:layout_constraintDimensionRatio="H,1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHeight_percent="0.5"

--- a/app/src/main/res/layout/view_camera.xml
+++ b/app/src/main/res/layout/view_camera.xml
@@ -15,6 +15,18 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton
+        android:id="@+id/camera_change"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_margin="8dp"
+        android:background="@android:color/transparent"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/camera_flip"
+        app:tint="@color/white" />
+
+    <ImageButton
         android:id="@+id/camera_torch"
         android:layout_width="32dp"
         android:layout_height="32dp"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -59,4 +59,8 @@
         <attr name="horizontal" format="boolean" />
     </declare-styleable>
 
+    <declare-styleable name="CameraView">
+        <attr name="flipEnable" format="boolean" />
+    </declare-styleable>
+
 </resources>


### PR DESCRIPTION
This improvement consists in the addition of the flip camera button and its behaviour within the `CameraView` component after integration on the Andromeda library. In order to enable the flip button, the `flipEnable` attribute was added to be set via xml, with a default value of false. The `camera_flip` icon downloaded from: https://pictogrammers.com/library/mdi/icon/camera-flip/ has been added.


In addition, the version of the Andromeda library was updated in the PR by pointing to the commit following the integration of the `flipCamera` method now exposed in the library. And in addition, although outside the scope of this improvement, the folder shelf within .idea has been added to the gitignore since shelves are generally used to store portions of code locally.