### PR TITLE
Improvement - Select QR image from Gallery

### DIFF
--- a/app/src/main/res/layout/fragment_scan_text.xml
+++ b/app/src/main/res/layout/fragment_scan_text.xml
@@ -20,6 +20,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/gallery"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="@string/select_from_gallery"
+        android:layout_marginTop="@dimen/default_top_margin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/camera" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/qr_history"
         android:layout_width="0dp"
@@ -28,8 +38,7 @@
         android:paddingTop="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/camera" />
+        app:layout_constraintTop_toBottomOf="@id/gallery" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -647,7 +647,7 @@
     <string name="map_auto_rotated">Map rotation adjusted with calibration</string>
     <string name="pref_backtrack_interval" translatable="false">pref_backtrack_interval</string>
     <string name="importing_map">Importing map</string>
-    <string name="importing_image">Importing image</string>
+    <string name="scanning_image">Scanning image</string>
     <string name="error_importing_map">Error importing map</string>
     <string name="import_gpx">Import GPX</string>
     <string name="sleep_timer">Sleep timer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -647,6 +647,7 @@
     <string name="map_auto_rotated">Map rotation adjusted with calibration</string>
     <string name="pref_backtrack_interval" translatable="false">pref_backtrack_interval</string>
     <string name="importing_map">Importing map</string>
+    <string name="importing_image">Importing image</string>
     <string name="error_importing_map">Error importing map</string>
     <string name="import_gpx">Import GPX</string>
     <string name="sleep_timer">Sleep timer</string>
@@ -824,6 +825,7 @@
     <string name="elevation_history">Elevation history</string>
     <string name="qr_code">QR Code</string>
     <string name="beacon_qr_import_instructions">Scan a QR code to import</string>
+    <string name="no_qr_code_detected">No QR code detected</string>
     <string name="last_duration">Last %s</string>
     <string name="elevation_history_length">Elevation history length</string>
     <string name="gps_signal_lost">GPS signal lost</string>
@@ -1363,4 +1365,5 @@
         <item quantity="one">%d path imported</item>
         <item quantity="other">%d paths imported</item>
     </plurals>
+    <string name="select_from_gallery">Select from Gallery</string>
 </resources>


### PR DESCRIPTION
The change consists of adding a button to be able to open the gallery and select an image of a QR code which will then be scanned. (https://github.com/kylecorry31/Trail-Sense/issues/1505)

### Description:
`PickVisualMedia` was used to open the image picker as it is the fastest and does not require user permissions.
Once the image uri has been extracted, an `AlertLoadingIndicator` is displayed (later removed at the end of the process).
The process consists of decoding the uri into a bitmap and then if the size of the bitmap (height and width) exceeds the max size, compressing it in the `compressBitmapToMaxSize` method.
Next, the `onCameraUpdate` method is called in which a small change has been made by adding the optional `isFromGallery` parameter (by default set to false), in order to display the no detection Toast.

Three strings have been added:
- importing_image, for AlertLoadingIndicator.
- no_qr_code_detected, for no detection Toast
- select_from_gallery, for UI button