### PR TITLE
 #2242  allow stopping battery log

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/receivers/TrailSenseServiceUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/receivers/TrailSenseServiceUtils.kt
@@ -33,7 +33,8 @@ object TrailSenseServiceUtils {
             startPedometer(appContext)
             startSunsetAlarm(appContext)
             startAstronomyAlerts(appContext)
-            BatteryLogWorker.start(appContext)
+            BatteryLogWorker.enableBatteryLog(appContext,
+                UserPreferences(appContext).power.enableBatteryLog)
             TileManager().setTilesEnabled(
                 appContext,
                 UserPreferences(appContext).power.areTilesEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
@@ -50,7 +51,7 @@ object TrailSenseServiceUtils {
         BacktrackService.stop(appContext)
         StepCounterService.stop(appContext)
         AstronomyDailyWorker.stop(appContext)
-        BatteryLogWorker.stop(appContext)
+        BatteryLogWorker.enableBatteryLog(appContext,false)
         SunsetAlarmReceiver.scheduler(appContext).cancel()
         TileManager().setTilesEnabled(appContext, false)
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PowerPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PowerPreferences.kt
@@ -17,5 +17,10 @@ class PowerPreferences(context: Context) : PreferenceRepo(context) {
         context.getString(R.string.pref_start_on_boot),
         true
     )
+    var enableBatteryLog by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_battery_log_enabled),
+        true
+    )
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/PowerSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/PowerSettingsFragment.kt
@@ -8,6 +8,7 @@ import com.kylecorry.trail_sense.receivers.StartOnBootController
 import com.kylecorry.trail_sense.tools.battery.infrastructure.LowPowerMode
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.tiles.TileManager
+import com.kylecorry.trail_sense.tools.battery.infrastructure.BatteryLogWorker
 
 class PowerSettingsFragment : AndromedaPreferenceFragment() {
 
@@ -41,6 +42,11 @@ class PowerSettingsFragment : AndromedaPreferenceFragment() {
         onClick(switch(R.string.pref_tiles_enabled)) {
             TileManager().setTilesEnabled(requireContext(), prefs.power.areTilesEnabled)
         }
+
+        onClick(switch(R.string.pref_battery_log_enabled)) {
+            BatteryLogWorker.enableBatteryLog(requireContext(),prefs.power.enableBatteryLog)
+        }
+
 
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryLogWorker.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryLogWorker.kt
@@ -20,12 +20,12 @@ class BatteryLogWorker(context: Context, params: WorkerParameters) :
 
         private const val UNIQUE_ID = 2739852
 
-        fun start(context: Context) {
-            scheduler(context).interval(Duration.ofHours(1))
-        }
-
-        fun stop(context: Context) {
-            scheduler(context).cancel()
+        fun enableBatteryLog(context: Context, enabled: Boolean) {
+            if(enabled) {
+                scheduler(context).interval(Duration.ofHours(1))
+            }else {
+                scheduler(context).cancel()
+            }
         }
 
         private fun scheduler(context: Context): IPeriodicTaskScheduler {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryLogWorker.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryLogWorker.kt
@@ -20,6 +20,12 @@ class BatteryLogWorker(context: Context, params: WorkerParameters) :
 
         private const val UNIQUE_ID = 2739852
 
+        /**
+         * This enable battery log worker to runs about every hour in order to accurately show battery drain
+         *
+         * enabled: Boolean: false cancel the process
+         * enabled: Boolean: true start the process
+         */
         fun enableBatteryLog(context: Context, enabled: Boolean) {
             if(enabled) {
                 scheduler(context).interval(Duration.ofHours(1))

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/ui/FragmentToolBattery.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/ui/FragmentToolBattery.kt
@@ -11,6 +11,7 @@ import com.kylecorry.andromeda.battery.Battery
 import com.kylecorry.andromeda.battery.BatteryChargingMethod
 import com.kylecorry.andromeda.battery.BatteryChargingStatus
 import com.kylecorry.andromeda.battery.BatteryHealth
+import com.kylecorry.andromeda.core.coroutines.onDefault
 import com.kylecorry.andromeda.core.system.Intents
 import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.andromeda.core.time.CoroutineTimer
@@ -24,14 +25,13 @@ import com.kylecorry.trail_sense.databinding.FragmentToolBatteryBinding
 import com.kylecorry.trail_sense.databinding.ListItemServiceBinding
 import com.kylecorry.trail_sense.shared.CustomUiUtils
 import com.kylecorry.trail_sense.shared.FormatService
-import com.kylecorry.trail_sense.tools.battery.infrastructure.LowPowerMode
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.colors.AppColor
-import com.kylecorry.andromeda.core.coroutines.onDefault
 import com.kylecorry.trail_sense.shared.safeRoundToInt
 import com.kylecorry.trail_sense.tools.battery.domain.BatteryReading
 import com.kylecorry.trail_sense.tools.battery.domain.RunningService
 import com.kylecorry.trail_sense.tools.battery.infrastructure.BatteryService
+import com.kylecorry.trail_sense.tools.battery.infrastructure.LowPowerMode
 import com.kylecorry.trail_sense.tools.battery.infrastructure.persistence.BatteryRepo
 import java.time.Duration
 import java.time.Instant

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -338,7 +338,15 @@
     <fragment
         android:id="@+id/fragmentToolBattery"
         android:name="com.kylecorry.trail_sense.tools.battery.ui.FragmentToolBattery"
-        android:label="FragmentToolBattery" />
+        android:label="FragmentToolBattery" >
+        <action
+            android:id="@+id/action_settings_to_power_settings"
+            app:destination="@id/powerSettingsFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
     <fragment
         android:id="@+id/fragmentToolTriangulate"
         android:name="com.kylecorry.trail_sense.tools.triangulate.ui.FragmentToolTriangulate"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,7 +740,8 @@
     <string name="pref_tiles_enabled_title">System tiles</string>
     <string name="pref_tiles_battery_log">Battery Log</string>
     <string name="pref_tiles_enabled_summary">May prevent battery saver apps from completely stopping Trail Sense</string>
-    <string name="pref_tiles_enabled_battery_log_summary">May prevent running battery log every hour in order to accurately show battery drain</string>
+    <string name="pref_dialog_battery_log_summary">The battery log is disabled, history and time until empty may be unavailable. You can re-enable this in settings</string>
+    <string name="pref_tiles_enabled_battery_log_summary">Logs battery percentage every hour to estimate time until empty</string>
     <string name="pref_flashlight_toggle_with_volume" translatable="false">pref_flashlight_toggle_with_volume</string>
     <string name="pref_flashlight_toggle_with_volume_summary">While Trail Sense is open</string>
     <string name="pref_flashlight_toggle_with_volume_title">Toggle with volume buttons</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -736,8 +736,11 @@
     <string name="location_mocked">Using mocked location</string>
     <string name="location_not_mocked">Using actual location</string>
     <string name="pref_tiles_enabled" translatable="false">pref_tiles_enabled</string>
+    <string name="pref_battery_log_enabled" translatable="false">pref_battery_log_enabled</string>
     <string name="pref_tiles_enabled_title">System tiles</string>
+    <string name="pref_tiles_battery_log">Battery Log</string>
     <string name="pref_tiles_enabled_summary">May prevent battery saver apps from completely stopping Trail Sense</string>
+    <string name="pref_tiles_enabled_battery_log_summary">May prevent running battery log every hour in order to accurately show battery drain</string>
     <string name="pref_flashlight_toggle_with_volume" translatable="false">pref_flashlight_toggle_with_volume</string>
     <string name="pref_flashlight_toggle_with_volume_summary">While Trail Sense is open</string>
     <string name="pref_flashlight_toggle_with_volume_title">Toggle with volume buttons</string>

--- a/app/src/main/res/xml/power_preferences.xml
+++ b/app/src/main/res/xml/power_preferences.xml
@@ -42,6 +42,14 @@
             app:summary="@string/pref_tiles_enabled_summary"
             app:title="@string/pref_tiles_enabled_title" />
 
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_battery_log_enabled"
+            app:singleLineTitle="false"
+            app:summary="@string/pref_tiles_enabled_battery_log_summary"
+            app:title="@string/pref_tiles_battery_log" />
+
 
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
fixes: #2242 

This MR address  #2242 which give user flexibility to enable/ disable the battery log from battery settings

![Screenshot_20240310_103123_Trail Sense](https://github.com/kylecorry31/Trail-Sense/assets/26343440/433536d3-559c-4006-8bb9-0d469bbfe54f)


@kylecorry31  where should this message be display, 
_display appropriate messages on the battery tool when disabled (can't calculate time until empty or show history)._
