### PR TITLE
UX: Open keyboard when pressing tools again

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -13,6 +13,7 @@ import android.view.KeyEvent
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.enableEdgeToEdge
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.core.view.ViewCompat
@@ -22,6 +23,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.google.android.material.navigation.NavigationBarView
+import com.google.android.material.textfield.TextInputEditText
 import com.kylecorry.andromeda.alerts.Alerts
 import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.andromeda.core.system.Screen
@@ -437,6 +439,17 @@ class MainActivity : AndromedaActivity() {
             4,
             getString(R.string.tools)
         ).setIcon(R.drawable.apps)
+        .setOnMenuItemClickListener {
+            if(navController.currentDestination?.id == R.id.action_experimental_tools && !binding.quickActionsSheet.isVisible) {
+                val searchinput = findViewById<TextInputEditText>(R.id.search_view_edit_text)
+                if (searchinput.requestFocus()) {
+                    val imm = getSystemService(InputMethodManager::class.java)
+                    imm.showSoftInput(searchinput, InputMethodManager.SHOW_IMPLICIT)
+                    return@setOnMenuItemClickListener true
+                }
+            }
+            false
+        }
 
         // Loop through each item of the bottom navigation and override the long press behavior
         for (i in 0 until binding.bottomNavigation.menu.size()) {


### PR DESCRIPTION
If you are in the tools fragment, you can click the tools entry in the bottomNav again to open the keyboard at the searchbox.
This is a ux feature that some other apps implement as well