### PR TITLE
feat(metaldetector): vibration toggle button

### DIFF
--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/metaldetector/ToolMetalDetectorTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/metaldetector/ToolMetalDetectorTest.kt
@@ -43,5 +43,11 @@ class ToolMetalDetectorTest : ToolTestBase(Tools.METAL_DETECTOR) {
         click(toolbarButton(R.id.metal_detector_title, Side.Right))
         click(toolbarButton(R.id.metal_detector_title, Side.Right))
         unmute(originalVolume)
+
+        // Can disable vibration
+        var buttonVibrationToggle = toolbarButton(R.id.metal_detector_title, Side.Left)
+        click(buttonVibrationToggle)
+        // TODO: assert button state and vibration subsystem state
+
     }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/MetalDetectorPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/MetalDetectorPreferences.kt
@@ -24,5 +24,9 @@ class MetalDetectorPreferences(context: Context): PreferenceRepo(context) {
         context.getString(R.string.pref_use_metal_audio),
         false
     )
-
+    var isMetalVibrationDisabled by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_no_use_metal_vibration),
+        false
+    )
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/metaldetector/ui/FragmentToolMetalDetector.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/metaldetector/ui/FragmentToolMetalDetector.kt
@@ -96,6 +96,7 @@ class FragmentToolMetalDetector : BoundFragment<FragmentToolMetalDetectorBinding
             prefs.metalDetector.isMetalAudioEnabled
         )
 
+        // Configure button: Metal Audio Toggle
         binding.metalDetectorTitle.rightButton.setOnClickListener {
             if (prefs.metalDetector.isMetalAudioEnabled) {
                 prefs.metalDetector.isMetalAudioEnabled = false
@@ -107,6 +108,25 @@ class FragmentToolMetalDetector : BoundFragment<FragmentToolMetalDetectorBinding
             CustomUiUtils.setButtonState(
                 binding.metalDetectorTitle.rightButton,
                 prefs.metalDetector.isMetalAudioEnabled
+            )
+        }
+
+        // Configure button: Metal Vibration Toggle
+        CustomUiUtils.setButtonState(
+            binding.metalDetectorTitle.leftButton,
+            !prefs.metalDetector.isMetalVibrationDisabled
+        )
+
+        binding.metalDetectorTitle.leftButton.setOnClickListener {
+            if (prefs.metalDetector.isMetalVibrationDisabled) {
+                prefs.metalDetector.isMetalVibrationDisabled = false
+            } else {
+                prefs.metalDetector.isMetalVibrationDisabled = true
+                haptics.off()
+            }
+            CustomUiUtils.setButtonState(
+                binding.metalDetectorTitle.leftButton,
+                !prefs.metalDetector.isMetalVibrationDisabled
             )
         }
     }
@@ -208,15 +228,27 @@ class FragmentToolMetalDetector : BoundFragment<FragmentToolMetalDetectorBinding
             Resources.androidTextColorSecondary(requireContext())
         )
 
-        if (metalDetected && !isVibrating) {
-            isVibrating = true
-            haptics.interval(VIBRATION_DURATION)
-        } else if (!metalDetected) {
-            isVibrating = false
-            haptics.off()
-        }
+        maybeVibrate(metalDetected)
 
         updateMetalSoundIntensity(magneticField)
+    }
+
+    /**
+     * [maybeVibrate] turns off vibration (haptics) if vibration is disabled
+     * or there is no metal detected.
+     * Otherwise vibration is triggered.
+     */
+    private fun maybeVibrate(metalDetected: Boolean) {
+        if (!metalDetected || prefs.metalDetector.isMetalVibrationDisabled) {
+            isVibrating = false
+            haptics.off()
+            return
+        }
+
+        if (!isVibrating) {
+            isVibrating = true
+            haptics.interval(VIBRATION_DURATION)
+        }
     }
 
     private fun updateMetalSoundIntensity(reading: Float) {

--- a/app/src/main/res/layout/fragment_tool_metal_detector.xml
+++ b/app/src/main/res/layout/fragment_tool_metal_detector.xml
@@ -13,6 +13,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:leftButtonIcon="@drawable/ic_notification"
         app:rightButtonIcon="@drawable/volume_up"
         app:showSubtitle="false"
         tools:title="65 uT" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1378,6 +1378,7 @@
     <string name="use_path_elevation">Use path elevation</string>
     <string name="pref_use_filtered_gps" translatable="false">pref_use_filtered_gps</string>
     <string name="pref_use_metal_audio" translatable="false">pref_use_metal_audio</string>
+    <string name="pref_no_use_metal_vibration" translatable="false">pref_no_use_metal_vibration</string>
     <string name="smooth_gps_readings">Smooth GPS readings</string>
     <plurals name="map_group_summary">
         <item quantity="one">%d map</item>


### PR DESCRIPTION
# Overview
Adds a button to toggle the Metal Detector tool's vibration. Vibration is enabled by default as before but can be toggled off by tapping the button. The button is added to the left side of the top toolbar:

![image](https://github.com/user-attachments/assets/84ae0be7-2cac-4119-ad42-0565d78d02dc)

## Relevant Issues
Resolves #2816

# Test Coverage

Basic android test in `ToolMetalDetectorTest.kt` was extended to try getting and clicking the vibration toggle button.

I wanted to assert the vibration is indeed enabled/disabled or at least assert that the vibration toggle button is in the correct state but I couldn't figure out how to do this. The button toggle state does not seem to be exposed.