### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release Upload
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/kylecorry31/Trail-Sense/security/code-scanning/6](https://github.com/kylecorry31/Trail-Sense/security/code-scanning/6)

To resolve this issue, we need to add a `permissions` block at the appropriate scope of the workflow file. Since only one job ("build") exists, setting it at the workflow or job level will suffice. The minimal permission required here for uploading release assets via a GitHub Action is `contents: write`. Some release upload actions may additionally require `issues: write` or `pull-requests: write`, but based on the shown steps, only uploading release assets (using the `Shopify/upload-to-release` action) is performed, so `contents: write` is sufficient. Edit the `.github/workflows/release.yml` file to add:

- A `permissions` block at the root (after the workflow `name:`) with `contents: write`

No imports or package changes are necessary; this is a YAML configuration in a workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
