### PR TITLE
chore: update field guide sighting name on map click

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/field_guide/map_layers/FieldGuideSightingGeoJsonSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/field_guide/map_layers/FieldGuideSightingGeoJsonSource.kt
@@ -16,6 +16,7 @@ import com.kylecorry.trail_sense.tools.field_guide.infrastructure.FieldGuideRepo
 class FieldGuideSightingGeoJsonSource : GeoJsonSource {
 
     private val repo = AppServiceRegistry.get<FieldGuideRepo>()
+    var nameFormat = ""
 
     private val tagIconMap = mapOf(
         FieldGuidePageTag.Plant to BeaconIcon.Plant,
@@ -52,7 +53,7 @@ class FieldGuideSightingGeoJsonSource : GeoJsonSource {
                 val point = GeoJsonFeature.point(
                     sighting.location!!,
                     sighting.id,
-                    page.name,
+                    nameFormat.format(page.name),
                     color = Color.BLACK,
                     icon = icon.id,
                     iconSize = 12f * 0.75f,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/field_guide/map_layers/FieldGuideSightingLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/field_guide/map_layers/FieldGuideSightingLayer.kt
@@ -1,11 +1,22 @@
 package com.kylecorry.trail_sense.tools.field_guide.map_layers
 
+import android.content.Context
+import com.kylecorry.andromeda.canvas.ICanvasDrawer
+import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IMapView
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.geojson.GeoJsonLayer
 
 class FieldGuideSightingLayer : GeoJsonLayer<FieldGuideSightingGeoJsonSource>(
     FieldGuideSightingGeoJsonSource(),
     layerId = LAYER_ID
 ) {
+
+    override fun draw(context: Context, drawer: ICanvasDrawer, map: IMapView) {
+        if (source.nameFormat.isEmpty()){
+            source.nameFormat = context.getString(R.string.sighting_label)
+        }
+        super.draw(context, drawer, map)
+    }
 
     companion object {
         const val LAYER_ID = "field_guide_sighting"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1889,4 +1889,6 @@
     <string name="move_layer_down">Move layer down</string>
     <string name="remove_layer">Remove layer</string>
     <string name="additional_layers">Additional layers</string>
+    <!--%s is the name of the field guide page-->
+    <string name="sighting_label">%s sighting</string>
 </resources>


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Display "sighting" after the field guide page name on the map.


## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#2914


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate
<!-- Generative AI use is heavily restricted in this repo, see the [Generative AI section of CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md#generative-ai) for more information. If you did not use generative AI, leave this box unchecked. -->
- [ ] Generative AI was used in the creation of this PR

<!-- If generative AI was used, please describe here what generative AI was used for and how you verified the accuracy. -->


## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

