### PR TITLE
fix: improve photo map loading speed

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/andromeda_temp/CoroutineObjectPool.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/andromeda_temp/CoroutineObjectPool.kt
@@ -1,0 +1,56 @@
+package com.kylecorry.trail_sense.shared.andromeda_temp
+
+import kotlinx.coroutines.channels.Channel
+import java.util.concurrent.atomic.AtomicInteger
+
+class CoroutineObjectPool<T : Any>(
+    private val maxSize: Int,
+    private val cleanup: suspend (T) -> Unit = {},
+    private val factory: suspend () -> T
+) {
+    private val channel = Channel<T>(maxSize)
+    private val created = AtomicInteger(0)
+
+    suspend fun acquire(): T {
+        channel.tryReceive().getOrNull()?.let { return it }
+
+        if (created.incrementAndGet() <= maxSize) {
+            return try {
+                factory()
+            } catch (e: Throwable) {
+                created.decrementAndGet()
+                throw e
+            }
+        } else {
+            created.decrementAndGet()
+        }
+
+        return channel.receive()
+    }
+
+    suspend fun release(obj: T) {
+        if (!channel.trySend(obj).isSuccess) {
+            cleanup(obj)
+            created.decrementAndGet()
+        }
+    }
+
+    suspend fun close() {
+        channel.close()
+        for (obj in channel) {
+            cleanup(obj)
+            created.decrementAndGet()
+        }
+    }
+}
+
+suspend inline fun <T : Any, R> CoroutineObjectPool<T>.use(
+    block: suspend (T) -> R
+): R {
+    val obj = acquire()
+    try {
+        return block(obj)
+    } finally {
+        release(obj)
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/ImageRegionDecoder.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/ImageRegionDecoder.kt
@@ -1,0 +1,66 @@
+package com.kylecorry.trail_sense.shared.canvas.tiles
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.BitmapRegionDecoder
+import android.graphics.Rect
+import android.net.Uri
+import android.os.Build
+import com.kylecorry.luna.coroutines.onIO
+import com.kylecorry.trail_sense.shared.andromeda_temp.CoroutineObjectPool
+import com.kylecorry.trail_sense.shared.andromeda_temp.use
+
+class ImageRegionDecoder(
+    private val context: Context,
+    private val bitmapConfig: Bitmap.Config = Bitmap.Config.RGB_565,
+    maxDecoders: Int = maxOf(4, Runtime.getRuntime().availableProcessors())
+) : RegionDecoder {
+
+    private val pool = CoroutineObjectPool(maxDecoders, cleanup = { it.recycle() }) {
+        createDecoder()
+    }
+    private var uri: Uri? = null
+    private var assetPath: String? = null
+
+    fun init(uri: Uri) {
+        this.uri = uri
+        assetPath = null
+    }
+
+    fun initFromAsset(assetPath: String) {
+        uri = null
+        this.assetPath = assetPath
+    }
+
+    private fun createDecoder(): BitmapRegionDecoder {
+        val inputStream = when {
+            uri != null -> context.contentResolver.openInputStream(uri!!)
+            assetPath != null -> context.assets.open(assetPath!!)
+            else -> null
+        } ?: error("Unable to open file")
+
+        return inputStream.use { stream ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                BitmapRegionDecoder.newInstance(stream)
+            } else {
+                @Suppress("DEPRECATION")
+                BitmapRegionDecoder.newInstance(stream, false)
+            }
+        } ?: error("Failed to create BitmapRegionDecoder")
+    }
+
+    override suspend fun decodeRegionSuspend(sRect: Rect, sampleSize: Int): Bitmap? = onIO {
+        pool.use { decoder ->
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = sampleSize
+                inPreferredConfig = bitmapConfig
+            }
+            decoder.decodeRegion(sRect, options)
+        }
+    }
+
+    override suspend fun recycleSuspend() {
+        pool.close()
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/PdfImageRegionDecoder.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/PdfImageRegionDecoder.kt
@@ -10,9 +10,11 @@ import androidx.core.graphics.toRectF
 import com.kylecorry.andromeda.core.math.MathUtils
 import com.kylecorry.andromeda.pdf.PDFRenderer2
 import com.kylecorry.andromeda.views.subscaleview.decoder.ImageRegionDecoder
+import com.kylecorry.luna.coroutines.onIO
 import com.kylecorry.trail_sense.tools.photo_maps.domain.PhotoMap
 
-class PdfImageRegionDecoder(private val bitmapConfig: Bitmap.Config? = null) : ImageRegionDecoder {
+class PdfImageRegionDecoder(private val bitmapConfig: Bitmap.Config? = null) : ImageRegionDecoder,
+    RegionDecoder {
 
     private lateinit var renderer: PDFRenderer2
 
@@ -48,6 +50,17 @@ class PdfImageRegionDecoder(private val bitmapConfig: Bitmap.Config? = null) : I
     }
 
     override fun recycle() {
+        renderer.close()
+    }
+
+    override suspend fun decodeRegionSuspend(
+        sRect: Rect,
+        sampleSize: Int
+    ): Bitmap = onIO {
+        decodeRegion(sRect, sampleSize)
+    }
+
+    override suspend fun recycleSuspend() = onIO {
         renderer.close()
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/RegionDecoder.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/canvas/tiles/RegionDecoder.kt
@@ -1,0 +1,9 @@
+package com.kylecorry.trail_sense.shared.canvas.tiles
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+
+interface RegionDecoder {
+    suspend fun decodeRegionSuspend(sRect: Rect, sampleSize: Int): Bitmap?
+    suspend fun recycleSuspend()
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapLayer.kt
@@ -1,9 +1,19 @@
 package com.kylecorry.trail_sense.tools.map.map_layers
 
+import com.kylecorry.trail_sense.shared.andromeda_temp.BackgroundTask
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileMapLayer
 
 class BaseMapLayer : TileMapLayer<BaseMapTileSource>(BaseMapTileSource()) {
     override val layerId: String = LAYER_ID
+
+    private val recycleTask = BackgroundTask {
+        source.recycle()
+    }
+
+    override fun stop() {
+        super.stop()
+        recycleTask.start()
+    }
 
     companion object {
         const val LAYER_ID = "base_map"

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
@@ -17,11 +17,13 @@ import com.kylecorry.trail_sense.tools.photo_maps.domain.MapMetadata
 import com.kylecorry.trail_sense.tools.photo_maps.domain.MapProjectionType
 import com.kylecorry.trail_sense.tools.photo_maps.domain.PercentCoordinate
 import com.kylecorry.trail_sense.tools.photo_maps.domain.PhotoMap
+import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles.PhotoMapDecoderCache
 import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles.PhotoMapTileSourceSelector
 
 class BaseMapTileSource : TileSource {
 
     private val context = AppServiceRegistry.get<Context>()
+    private val decoderCache = PhotoMapDecoderCache()
     private val internalSelector = PhotoMapTileSourceSelector(
         context,
         listOf(
@@ -51,6 +53,7 @@ class BaseMapTileSource : TileSource {
                 isFullWorld = true // TODO: Derive this using calibration points
             )
         ),
+        decoderCache,
         maxLayers = 1,
         loadPdfs = false,
         isPixelPerfect = true,
@@ -102,6 +105,10 @@ class BaseMapTileSource : TileSource {
 
     override suspend fun load(tiles: List<Tile>, onLoaded: suspend (Tile, Bitmap?) -> Unit) {
         internalSelector.load(tiles, onLoaded)
+    }
+
+    suspend fun recycle() {
+        decoderCache.recycleInactive(emptyList())
     }
 
     companion object {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/tiles/PhotoMapDecoderCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/tiles/PhotoMapDecoderCache.kt
@@ -1,0 +1,91 @@
+package com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Rect
+import com.kylecorry.andromeda.core.cache.AppServiceRegistry
+import com.kylecorry.andromeda.core.tryOrDefault
+import com.kylecorry.trail_sense.shared.canvas.tiles.ImageRegionDecoder
+import com.kylecorry.trail_sense.shared.canvas.tiles.PdfImageRegionDecoder
+import com.kylecorry.trail_sense.shared.canvas.tiles.RegionDecoder
+import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import com.kylecorry.trail_sense.tools.photo_maps.domain.PhotoMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+
+class PhotoMapDecoderCache {
+    private val loaders = ConcurrentHashMap<PhotoMap, RegionDecoder>()
+    private val mutexes = ConcurrentHashMap<PhotoMap, Mutex>()
+    private val files = AppServiceRegistry.get<FileSubsystem>()
+
+    private fun getLock(map: PhotoMap): Mutex {
+        return mutexes.getOrPut(map) { Mutex() }
+    }
+
+    private suspend fun getPdfLoader(
+        context: Context,
+        map: PhotoMap
+    ): RegionDecoder {
+        loaders[map]?.let { return it }
+
+        return getLock(map).withLock {
+            loaders[map]?.let { return it }
+            val decoder = PdfImageRegionDecoder(Bitmap.Config.ARGB_8888)
+            decoder.init(context, files.uri(map.pdfFileName))
+            loaders[map] = decoder
+            decoder
+        }
+    }
+
+    private suspend fun getImageLoader(
+        context: Context,
+        map: PhotoMap
+    ): RegionDecoder {
+        loaders[map]?.let { return it }
+
+        return getLock(map).withLock {
+            loaders[map]?.let { return it }
+            val decoder = ImageRegionDecoder(context, Bitmap.Config.ARGB_8888)
+
+            if (map.isAsset) {
+                decoder.initFromAsset(map.filename.removePrefix(files.SCHEME_ASSETS))
+            } else {
+                decoder.init(files.uri(map.filename))
+            }
+
+            loaders[map] = decoder
+            decoder
+        }
+    }
+
+    suspend fun decodeRegion(
+        context: Context,
+        map: PhotoMap,
+        region: Rect,
+        sampleSize: Int,
+        isPdf: Boolean
+    ): Bitmap? {
+        return tryOrDefault(null) {
+            val loader = if (isPdf) {
+                getPdfLoader(context, map)
+            } else {
+                getImageLoader(context, map)
+            }
+            loader.decodeRegionSuspend(region, sampleSize)
+        }
+    }
+
+    suspend fun recycleInactive(activeMaps: List<PhotoMap>) {
+        val activeSet = activeMaps.toSet()
+
+        loaders.keys
+            .filter { it !in activeSet }
+            .forEach { map ->
+                getLock(map).withLock {
+                    loaders.remove(map)?.recycleSuspend()
+                    mutexes.remove(map)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
@@ -3,17 +3,20 @@ package com.kylecorry.trail_sense.tools.photo_maps.map_layers
 import android.graphics.Color
 import android.os.Bundle
 import com.kylecorry.sol.science.geology.CoordinateBounds
+import com.kylecorry.trail_sense.shared.andromeda_temp.BackgroundTask
 import com.kylecorry.trail_sense.shared.map_layers.tiles.TileMath
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileMapLayer
 import com.kylecorry.trail_sense.tools.photo_maps.domain.PhotoMap
-import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles.PhotoMapRegionLoader
 
 class PhotoMapLayer : TileMapLayer<PhotoMapTileSource>(
-    PhotoMapTileSource(pruneCache = true),
+    PhotoMapTileSource(),
     minZoomLevel = 4
 ) {
 
     override val layerId: String = LAYER_ID
+    private val recycleTask = BackgroundTask {
+        source.recycle()
+    }
 
     init {
         source.backgroundColor = Color.TRANSPARENT
@@ -47,7 +50,7 @@ class PhotoMapLayer : TileMapLayer<PhotoMapTileSource>(
 
     override fun stop() {
         super.stop()
-        PhotoMapRegionLoader.removeUnneededLoaders(emptyList())
+        recycleTask.start()
     }
 
     companion object {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapTileSource.kt
@@ -7,34 +7,34 @@ import com.kylecorry.trail_sense.shared.map_layers.tiles.Tile
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
 import com.kylecorry.trail_sense.tools.photo_maps.domain.PhotoMap
 import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.MapRepo
+import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles.PhotoMapDecoderCache
 import com.kylecorry.trail_sense.tools.photo_maps.infrastructure.tiles.PhotoMapTileSourceSelector
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class PhotoMapTileSource(
-    var backgroundColor: Int = Color.WHITE,
-    private val pruneCache: Boolean = false,
-) : TileSource {
+class PhotoMapTileSource : TileSource {
 
     var filter: (map: PhotoMap) -> Boolean = { it.visible }
     var loadPdfs = true
     private var lastLoadPdfs = loadPdfs
+    var backgroundColor: Int = Color.WHITE
     private var lastBackgroundColor = backgroundColor
     private var lastFilter = filter
     private var internalSelector: TileSource? = null
     private val lock = Mutex()
+    private val decoderCache = PhotoMapDecoderCache()
 
-    override suspend fun load(tiles: List<Tile>, onLoaded: suspend  (Tile, Bitmap?) -> Unit) {
+    override suspend fun load(tiles: List<Tile>, onLoaded: suspend (Tile, Bitmap?) -> Unit) {
         val selector = lock.withLock {
             if (internalSelector == null || loadPdfs != lastLoadPdfs || backgroundColor != lastBackgroundColor || filter != lastFilter) {
                 val repo = AppServiceRegistry.get<MapRepo>()
                 internalSelector = PhotoMapTileSourceSelector(
                     AppServiceRegistry.get(),
                     repo.getAllMaps().filter(filter),
+                    decoderCache,
                     8,
                     loadPdfs,
-                    backgroundColor = backgroundColor,
-                    pruneCache = pruneCache
+                    backgroundColor = backgroundColor
                 )
                 lastLoadPdfs = loadPdfs
                 lastBackgroundColor = backgroundColor
@@ -43,5 +43,9 @@ class PhotoMapTileSource(
             internalSelector
         }
         selector?.load(tiles, onLoaded)
+    }
+
+    suspend fun recycle() {
+        decoderCache.recycleInactive(emptyList())
     }
 }


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
- Cache bitmap decoders
- Suspend instead of synchronized

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3351 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate
<!-- Generative AI use is heavily restricted in this repo, see the [Generative AI section of CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md#generative-ai) for more information. If you did not use generative AI, leave this box unchecked. -->
- [ ] Generative AI was used in the creation of this PR

<!-- If generative AI was used, please describe here what generative AI was used for and how you verified the accuracy. -->


## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

