### PR TITLE
feat: hide blank maps on photo map layer by default

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/create/CreateBlankMapCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/create/CreateBlankMapCommand.kt
@@ -70,7 +70,8 @@ class CreateBlankMapCommand(
                     rotated = true,
                     rotation = 0f,
                     calibrationPoints = calibration
-                )
+                ),
+                visible = false
             )
 
             calibrated?.let { repo.addMap(it) }


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Hide blank photo maps by default on the photo map layer and actions. Users can override this the same as any other map.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3367

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

