### PR TITLE
fix: photo map cache invalidation

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
@@ -40,7 +40,7 @@ class PhotoMapLayer : TileMapLayer<PhotoMapTileSource>(
         val keys = mutableListOf(layerId)
         keys.add(source.loadPdfs.toString())
         idFilter?.let { keys.add(it.toString()) }
-        return keys.joinToString(",")
+        return keys.joinToString("-")
     }
 
     fun improveResolution(


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Fixes photo map cache invalidation when a map is changed.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3364 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

