### PR TITLE
fix: extra tile load at antimeridian

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileMath.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileMath.kt
@@ -36,8 +36,14 @@ object TileMath {
         val minLat = max(bounds.south, MIN_LATITUDE)
         val maxLat = min(bounds.north, MAX_LATITUDE)
 
-        val (xMin, yMax) = getTile(minLat, bounds.west, zoom)
-        val (xMax, yMin) = getTile(maxLat, bounds.east, zoom)
+        val southWest = getTile(minLat, bounds.west, zoom)
+        val northEast = getTile(maxLat, bounds.east, zoom)
+
+        val n = 1 shl zoom
+        val xMin = southWest.x.coerceAtMost(n - 1)
+        val xMax = northEast.x.coerceAtMost(n - 1)
+        val yMin = northEast.y.coerceAtMost(n - 1)
+        val yMax = southWest.y.coerceAtMost(n - 1)
 
         // If range is greater than 100, return an empty list
         if (xMax - xMin > 100 || yMax - yMin > 100) {


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
An extra set of tiles was being loaded at the antimeridian due to an off by one issue

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

