### PR TITLE
fix: fading tiles on devices without compass

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -341,6 +341,10 @@ abstract class TileMapLayer<T : TileSource>(
             // Calculate alpha for fade-in effect
             val originalAlpha = tilePaint.alpha
             tilePaint.alpha = imageTile.getAlpha()
+            // There are still tiles being faded in, so keep re-rendering the map
+            if (tilePaint.alpha != 255){
+                notifyListeners()
+            }
 
             drawBitmap(bitmap, srcRect, destRect, tilePaint)
 
@@ -372,7 +376,7 @@ abstract class TileMapLayer<T : TileSource>(
             tag = layerId,
             key = getCacheKey()
         ) {
-            updateListener?.invoke()
+            notifyListeners()
         }
         loadTimer.interval(100)
     }


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
While tiles are fading in, invalidate the map view.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

