### PR TITLE
fix: tile refreshing is less jarring

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
@@ -30,7 +30,7 @@ class TileQueue {
         }
     }
 
-    fun setDesiredTiles(tiles: List<Tile>){
+    fun setDesiredTiles(tiles: List<Tile>) {
         desiredTiles = tiles.toSet()
     }
 
@@ -78,7 +78,7 @@ class TileQueue {
 
             val key = tile.key
             val tileState = tile.state
-            if (tileState == TileState.Idle) {
+            if (tileState == TileState.Idle || tileState == TileState.Stale) {
                 val shouldLoad = synchronized(loadingKeys) {
                     loadingKeys.add(key)
                 }
@@ -100,10 +100,8 @@ class TileQueue {
     }
 
     private fun onStateChange(tile: ImageTile) {
-        if (tile.state == TileState.Loaded || tile.state == TileState.Error || tile.state == TileState.Empty) {
-            synchronized(loadingKeys) {
-                loadingKeys.remove(tile.key)
-            }
+        synchronized(loadingKeys) {
+            loadingKeys.remove(tile.key)
         }
         changeListener(tile)
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -223,7 +223,7 @@ abstract class TileMapLayer<T : TileSource>(
     }
 
     private fun isTileAvailable(tile: ImageTile?): Boolean {
-        return tile?.state == TileState.Loaded || tile?.state == TileState.Empty
+        return tile?.state == TileState.Loaded || tile?.state == TileState.Empty || tile?.state == TileState.Stale
     }
 
     private fun isTooSmall(
@@ -342,7 +342,7 @@ abstract class TileMapLayer<T : TileSource>(
             val originalAlpha = tilePaint.alpha
             tilePaint.alpha = imageTile.getAlpha()
             // There are still tiles being faded in, so keep re-rendering the map
-            if (tilePaint.alpha != 255){
+            if (tilePaint.alpha != 255) {
                 notifyListeners()
             }
 
@@ -395,7 +395,7 @@ abstract class TileMapLayer<T : TileSource>(
         resetTime()
         loadTimer.stop()
         queue.clear()
-        loader?.clearCache()
+        loader?.tileCache?.snapshot()?.forEach { it.value.state = TileState.Stale }
         loadTimer.interval(100)
         invalidate()
         notifyListeners()


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Mark tiles as stale so they still render while a new version is loading.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

