### PR TITLE
fix: use actual altitude for night layer

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
@@ -485,6 +485,7 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
 
     companion object {
         private val altitudeGranularity = Duration.ofMinutes(10)
+        const val SUN_MIN_ALTITUDE_ACTUAL = -0.8333f
         const val SUN_MIN_ALTITUDE_CIVIL = -6f
         const val SUN_MIN_ALTITUDE_NAUTICAL = -12f
         const val SUN_MIN_ALTITUDE_ASTRONOMICAL = -18f

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/map_layers/NightTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/map_layers/NightTileSource.kt
@@ -1,7 +1,6 @@
 package com.kylecorry.trail_sense.tools.astronomy.map_layers
 
 import android.content.Context
-
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
@@ -18,8 +17,8 @@ import com.kylecorry.trail_sense.shared.map_layers.tiles.InterpolatedGridValuePr
 import com.kylecorry.trail_sense.shared.map_layers.tiles.ParallelCoordinateGridValueProvider
 import com.kylecorry.trail_sense.shared.map_layers.tiles.Tile
 import com.kylecorry.trail_sense.shared.map_layers.tiles.TileImageUtils
-import com.kylecorry.trail_sense.shared.map_layers.ui.layers.getPreferences
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.MapLayerParams
+import com.kylecorry.trail_sense.shared.map_layers.ui.layers.getPreferences
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
 import java.time.Instant
@@ -99,7 +98,7 @@ class NightTileSource : TileSource {
                 value <= AstronomyService.SUN_MIN_ALTITUDE_ASTRONOMICAL -> 1f
                 value <= AstronomyService.SUN_MIN_ALTITUDE_NAUTICAL -> 0.75f
                 value <= AstronomyService.SUN_MIN_ALTITUDE_CIVIL -> 0.5f
-                value <= 0 -> 0.25f
+                value <= AstronomyService.SUN_MIN_ALTITUDE_ACTUAL -> 0.25f
                 else -> 0f
             }
             table.alpha[i] = colorMap.getColor(pct).alpha.toByte()


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Use actual altitude for night layer so it matches sunrise/set time

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3430 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

