### PR TITLE
fix: map pdf not visible on calibrate fragment

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,8 +23,8 @@
 -keepnames class * extends java.io.Serializable
 -keep class * extends com.kylecorry.trail_sense.shared.ProguardIgnore { *; }
 -keep class * extends androidx.fragment.app.Fragment{}
--keep class * extends com.kylecorry.andromeda.views.subscaleview.decoder.ImageDecoder
--keep class * extends com.kylecorry.andromeda.views.subscaleview.decoder.ImageRegionDecoder
+-keep class * extends com.kylecorry.andromeda.views.subscaleview.decoder.ImageDecoder { *; }
+-keep class * extends com.kylecorry.andromeda.views.subscaleview.decoder.ImageRegionDecoder { *; }
 -keep class com.kylecorry.andromeda.bitmaps.Range2d { *; }
 -keep class com.kylecorry.andromeda.bitmaps.Toolkit { *; }
 


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
I believe this is due to the AGP upgrade - it was optimizing out the no param constructor which was loaded via reflection on the subsample scale image view library.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3481 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

