### PR TITLE
fix: don't render lines behind the camera in AR

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/AugmentedRealityView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/AugmentedRealityView.kt
@@ -27,11 +27,11 @@ import com.kylecorry.andromeda.sense.orientation.IOrientationSensor
 import com.kylecorry.luna.coroutines.CoroutineQueueRunner
 import com.kylecorry.luna.hooks.Hooks
 import com.kylecorry.sol.math.Euler
-import com.kylecorry.sol.math.Quaternion
-import com.kylecorry.sol.math.trigonometry.Trigonometry.deltaAngle
 import com.kylecorry.sol.math.MathExtensions.toDegrees
+import com.kylecorry.sol.math.Quaternion
 import com.kylecorry.sol.math.Vector3
 import com.kylecorry.sol.math.geometry.Size
+import com.kylecorry.sol.math.trigonometry.Trigonometry.deltaAngle
 import com.kylecorry.sol.units.Bearing
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.shared.FormatService
@@ -452,8 +452,19 @@ class AugmentedRealityView : CanvasView {
      * @param coordinate The augmented reality coordinate of the point
      * @return The pixel coordinate of the point
      */
-    fun toPixel(coordinate: AugmentedRealityCoordinate): PixelCoordinate {
+    fun toPixel(
+        coordinate: AugmentedRealityCoordinate,
+        nanIfBehindCamera: Boolean = false
+    ): PixelCoordinate {
         val actual = getActualPoint(coordinate.position, coordinate.isTrueNorth)
+
+        if (nanIfBehindCamera) {
+            val arPoint = AugmentedRealityUtils.enuToAr(actual, rotationMatrix)
+            if (arPoint.z <= 0f || !arPoint.z.isFinite()) {
+                return PixelCoordinate(Float.NaN, Float.NaN)
+            }
+        }
+
         val screenPixel = AugmentedRealityUtils.getPixel(
             actual,
             rotationMatrix,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/layers/ARLineLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/layers/ARLineLayer.kt
@@ -5,6 +5,7 @@ import com.kylecorry.andromeda.canvas.ICanvasDrawer
 import com.kylecorry.andromeda.canvas.StrokeCap
 import com.kylecorry.andromeda.core.cache.ObjectPool
 import com.kylecorry.andromeda.core.units.PixelCoordinate
+import com.kylecorry.trail_sense.shared.camera.AugmentedRealityUtils
 import com.kylecorry.trail_sense.shared.canvas.LineClipper
 import com.kylecorry.trail_sense.shared.extensions.drawLines
 import com.kylecorry.trail_sense.shared.getViewBounds
@@ -127,7 +128,7 @@ class ARLineLayer(
         view: AugmentedRealityView
     ): FloatArray {
         val bounds = view.getViewBounds()
-        val pixels = points.map { view.toPixel(it) }
+        val pixels = points.map { view.toPixel(it, true) }
 
         val lines = mutableListOf<Float>()
         clipper.clip(pixels, bounds, lines, preventLineWrapping = true)


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
It was rendering lines that were behind the camera when zoomed way out

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#2663 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

