### PR TITLE
fix: cardinal direction color white on compass

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/RadarCompassView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/RadarCompassView.kt
@@ -220,7 +220,7 @@ class RadarCompassView : BaseCompassView, IMapView {
     private fun drawDirection(degrees: Float, text: String) {
         push()
         rotate(degrees)
-        fill(primaryColor)
+        fill(Color.WHITE)
         text(
             text,
             width / 2f,


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Restore cardinal direction color to white

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#1796 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

