### PR TITLE
refactor: move cache keys to layer constructor

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/MapRepo.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/infrastructure/MapRepo.kt
@@ -83,8 +83,10 @@ class MapRepo private constructor(private val context: Context) : IMapRepo {
         val cacheKeys = listOf(
             "${PhotoMapTileSource.SOURCE_ID}-true-$mapId",
             "${PhotoMapTileSource.SOURCE_ID}-false-$mapId",
+            "${PhotoMapTileSource.SOURCE_ID}-null-$mapId",
             "${PhotoMapTileSource.SOURCE_ID}-true",
             "${PhotoMapTileSource.SOURCE_ID}-false",
+            "${PhotoMapTileSource.SOURCE_ID}-null",
         )
         cacheKeys.forEach {
             tileCache.invalidate(it)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/map_layers/PhotoMapLayer.kt
@@ -1,26 +1,12 @@
 package com.kylecorry.trail_sense.tools.photo_maps.map_layers
 
-import android.os.Bundle
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileMapLayer
 
 class PhotoMapLayer : TileMapLayer<PhotoMapTileSource>(
     PhotoMapTileSource(),
     PhotoMapTileSource.SOURCE_ID,
-    minZoomLevel = 4
-) {
-    private var loadPdfs: Boolean = PhotoMapTileSource.DEFAULT_LOAD_PDFS
-
-    override fun setPreferences(preferences: Bundle) {
-        super.setPreferences(preferences)
-        loadPdfs = preferences.getBoolean(
-            PhotoMapTileSource.LOAD_PDFS,
-            PhotoMapTileSource.DEFAULT_LOAD_PDFS
-        )
-    }
-
-    override fun getBaseCacheKey(): String {
-        val keys = mutableListOf(layerId)
-        keys.add(loadPdfs.toString())
-        return keys.joinToString("-")
-    }
-}
+    minZoomLevel = 4,
+    cacheKeys = listOf(
+        PhotoMapTileSource.LOAD_PDFS
+    )
+)


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
- Move cache keys to layer constructor
- Make cache key generation generic
- Use layer constructor cache keys for photo maps

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3447 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

