### PR TITLE
fix: catch and ignore battery intent exceptions

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
@@ -7,6 +7,7 @@ import android.provider.Settings
 import com.kylecorry.andromeda.battery.IBattery
 import com.kylecorry.andromeda.core.system.Intents
 import com.kylecorry.andromeda.core.tryOrDefault
+import com.kylecorry.andromeda.core.tryOrLog
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.tools.battery.domain.BatteryReading
 import com.kylecorry.trail_sense.tools.battery.domain.BatteryUsage
@@ -154,7 +155,7 @@ class BatteryService {
     private fun getSystemAction(context: Context, action: String): ((Context) -> Unit)? {
         val intent = Intent(action)
         if (Intents.hasReceiver(context, intent)) {
-            return { context: Context -> context.startActivity(intent) }
+            return { context: Context -> tryOrLog { context.startActivity(intent) } }
         }
         return null
     }


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Prevents a crash, doesn't attempt to open settings since this is really rare and I don't want to deal with device manufacturer workarounds.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3462

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

