### PR TITLE
fix: draw azimuth indicator when no bezel

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/RadarCompassView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/RadarCompassView.kt
@@ -79,6 +79,7 @@ class RadarCompassView : BaseCompassView {
     )
 
     private fun drawAzimuth() {
+        fill(Color.WHITE)
         tint(
             if (drawDialBezel) Color.WHITE.withAlpha(220) else Resources.androidTextColorPrimary(
                 context


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Shows the azimuth indicator when the bezel is disabled

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#1796 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] My code attempts to follow the code style of this project
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

