### PR TITLE
Show clock source in clock tool

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/clock/ui/ToolClockFragment.kt
@@ -40,6 +40,7 @@ class ToolClockFragment : BoundFragment<FragmentToolClockBinding>() {
 
     private var gpsTime = Instant.now()
     private var systemTime = Instant.now()
+    private var isGpsTime = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -78,14 +79,17 @@ class ToolClockFragment : BoundFragment<FragmentToolClockBinding>() {
     private fun onGPSUpdate(): Boolean {
         gpsTime = getGPSTime()
         systemTime = Instant.now()
+        isGpsTime = true
 
         if (gps is CustomGPS && (gps as CustomGPS).isTimedOut) {
             Alerts.toast(requireContext(), getString(R.string.no_gps_signal))
             gpsTime = Instant.now()
+            isGpsTime = false
         }
 
         binding.updatingClock.visibility = View.INVISIBLE
         binding.pipButton.visibility = View.VISIBLE
+        updateClockSource()
         return false
     }
 
@@ -117,6 +121,15 @@ class ToolClockFragment : BoundFragment<FragmentToolClockBinding>() {
             binding.digitalClock.text = formatService.formatTime(myTime.toLocalTime())
         }
 
+    }
+
+    private fun updateClockSource() {
+        binding.clockSource.text = if (isGpsTime) {
+            getString(R.string.clock_source_gps)
+        } else {
+            getString(R.string.clock_source_device)
+        }
+        binding.clockSource.visibility = View.VISIBLE
     }
 
     private fun sendNextMinuteNotification() {

--- a/app/src/main/res/layout/fragment_tool_clock.xml
+++ b/app/src/main/res/layout/fragment_tool_clock.xml
@@ -38,6 +38,17 @@
         app:layout_constraintTop_toTopOf="@+id/analog_clock" />
 
     <TextView
+        android:id="@+id/clock_source"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/default_bottom_margin"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        android:textColor="?android:textColorSecondary"
+        app:layout_constraintBottom_toTopOf="@+id/updating_clock"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
         android:id="@+id/updating_clock"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,6 +436,8 @@
     <string name="water_purification_step_2">Bring water to a rolling boil</string>
     <string name="water_purification_step_3">Start the timer</string>
     <string name="clock_waiting_for_gps">Updating time from GPS…</string>
+    <string name="clock_source_device">Device time</string>
+    <string name="clock_source_gps">GPS time</string>
     <string name="pref_fine_with_strobe" translatable="false">pref_fine_with_strobe</string>
     <string name="strobe_warning_title">Flashing lights</string>
     <string name="strobe_warning_content">The strobe feature contains flashing lights, which may be dangerous for some users.</string>


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Adds a label below the clock indicating whether the displayed time is from the device or GPS.

Changes:
- Added clock_source TextView to fragment_tool_clock.xml layout
- Added clock_source_device and clock_source_gps string resources
- Updated ToolClockFragment to track GPS vs device time and display the source

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3576

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [ ] My code attempts to follow the code style of this project
- [ ] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->