### PR TITLE
fix: NaN rounding exception when a photo map width or height is 0

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/domain/projections/CalibratedProjection.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/photo_maps/domain/projections/CalibratedProjection.kt
@@ -1,9 +1,10 @@
 package com.kylecorry.trail_sense.tools.photo_maps.domain.projections
 
 import com.kylecorry.andromeda.core.units.PixelCoordinate
+import com.kylecorry.sol.math.Vector2
+import com.kylecorry.sol.math.arithmetic.Arithmetic
 import com.kylecorry.sol.math.interpolation.Interpolation.map
 import com.kylecorry.sol.math.interpolation.Interpolation.norm
-import com.kylecorry.sol.math.Vector2
 import com.kylecorry.sol.science.geography.projections.IMapProjection
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.sol.units.Coordinate
@@ -26,7 +27,10 @@ class CalibratedProjection(
 
 
     override fun toCoordinate(pixel: Vector2): Coordinate {
-        if (left == null || top == null) {
+        val hasZeroSize = Arithmetic.isZero(width) || Arithmetic.isZero(height)
+        val hasInvalidCorner = left == null || top == null
+
+        if (hasInvalidCorner || hasZeroSize) {
             return Coordinate.zero
         }
 


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->


## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3652

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

