### PR TITLE
fix: set navigator offline maps layer to half opacity by default

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/settings/migrations/PreferenceMigrator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/migrations/PreferenceMigrator.kt
@@ -454,6 +454,12 @@ class PreferenceMigrator private constructor() {
                         idealOrdering
                     )
                 }
+
+                val navigationOfflineMapOpacityKey =
+                    "pref_${NavigationToolRegistration.MAP_ID}_${OfflineMapTileSource.SOURCE_ID}_layer_opacity"
+                if (!prefs.contains(navigationOfflineMapOpacityKey)) {
+                    prefs.putInt(navigationOfflineMapOpacityKey, 50)
+                }
             }
         )
 


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->


## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3686 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

