### PR TITLE
feat: show date above meteor shower time where needed

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/BaseAstroListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/BaseAstroListItemProducer.kt
@@ -158,26 +158,34 @@ abstract class BaseAstroListItemProducer(protected val context: Context) :
         end: ZonedDateTime?,
         displayDate: LocalDate? = start?.toLocalDate()
     ): List<ListItemData> {
+        val reserveHeaderSpace = listOf(start, peak, end).any { it != null && it.toLocalDate() != displayDate }
         return listOf(
             context.getString(R.string.start_time) to start,
             context.getString(R.string.peak_time) to peak,
             context.getString(R.string.end_time) to end
         ).flatMap {
-            time(it.second, displayDate, it.first)
+            time(it.second, displayDate, it.first, reserveHeaderSpace)
         }
     }
 
     protected fun time(
         time: ZonedDateTime?,
         displayDate: LocalDate? = time?.toLocalDate(),
-        todayLabel: CharSequence? = null
+        label: CharSequence? = null,
+        reserveHeaderSpace: Boolean = false
     ): List<ListItemData> {
-        val label = if (time != null && time.toLocalDate() != displayDate) {
-            formatter.formatRelativeDate(time.toLocalDate(), true)
-        } else {
-            todayLabel
+
+        val value = buildSpannedString {
+            scale(0.75f) {
+                if (time != null && time.toLocalDate() != displayDate) {
+                    appendLine(formatter.formatRelativeDate(time.toLocalDate(), true))
+                } else if (reserveHeaderSpace) {
+                    appendLine()
+                }
+            }
+            append(formatTime(time))
         }
-        return listOf(datapoint(formatTime(time), label))
+        return listOf(datapoint(value, label))
     }
 
 


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
Shows the date above the meteor shower time instead of below it, so below will always show start, peak, end.

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3701 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

