### PR TITLE
fix: map widget transparent tiles

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -7,6 +7,7 @@ class ImageTile(
     val tile: Tile,
     private var image: Bitmap? = null,
     var state: TileState = TileState.Idle,
+    private val shouldFadeIn: Boolean = true,
     loadFunction: (suspend () -> Bitmap?)?
 ) {
 
@@ -16,6 +17,9 @@ class ImageTile(
 
     var loadingStartTime: Long? = null
     fun getAlpha(): Int {
+        if (!shouldFadeIn) {
+            return 255
+        }
         return loadingStartTime?.let { startTime ->
             val elapsed = System.currentTimeMillis() - startTime
             if (elapsed >= 250) {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -86,6 +86,7 @@ class TileLoader(
                 ImageTile(
                     key = key,
                     tile = tile,
+                    shouldFadeIn = !isWidget,
                     loadFunction = {
                         loadTile(source, context, tile, params)
                     }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -87,7 +87,7 @@ open class TileMapLayer<T : TileSource>(
 
     private val loadTimer = CoroutineTimer {
         queue.load(16)
-        isLoaded = queue.count() == 0
+        isLoaded = queue.count() == 0 && queue.getLoadingCount() == 0
     }
     private val refreshTimer = refreshInterval?.let { CoroutineTimer { refresh() } }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/map/widgets/MapToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/map/widgets/MapToolWidgetView.kt
@@ -2,6 +2,7 @@ package com.kylecorry.trail_sense.tools.map.widgets
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Path
 import android.view.View
 import android.widget.RemoteViews
@@ -39,6 +40,7 @@ class MapToolWidgetView : ChartToolWidgetViewBase() {
             val size = Resources.dp(context, 400f).toInt()
             val cornerRadius = Resources.dp(context, 8f)
             val mapView = MapView(context)
+            mapView.backgroundColorOverride = Color.rgb(127, 127, 127)
             mapView.clipPath = Path().apply {
                 if (drawAsCircle) {
                     addCircle(size / 2f, size / 2f, size / 2f, Path.Direction.CW)


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
- Don't fade tiles in while in widget mode
- Add background color to widget map to match other instances
- Check both queued and loading tile counts

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3739

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

