### PR TITLE
fix: only check display rotation on Android 16 and up

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/MainActivity.kt
@@ -544,10 +544,10 @@ class MainActivity : AndromedaActivity() {
 
     @Suppress("DEPRECATION")
     private fun updateDeviceSurfaceRotation() {
-        deviceSurfaceRotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        deviceSurfaceRotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
             display?.rotation ?: windowManager.defaultDisplay.rotation
         } else {
-            windowManager.defaultDisplay.rotation
+            Surface.ROTATION_90
         }
     }
 


### PR DESCRIPTION
<!-- You must use the following template for pull requests - do not delete any of the sections or checkboxes. -->

## Description
<!-- Describe what this PR does and why -->
My theory is that checking the display rotation when the device is portrait locked is encountering a bug on Samsung A52 Android 12. This really shouldn't be needed, but...

## Related Issue
<!-- Link to the issue this PR addresses or contributes under. I will close out issues once my testing of the merged PR is complete. -->
#3810 

## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested my changes on an Android device or emulator
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

