### PR TITLE
Add widget icon compatibility mode setting

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/ExperimentalSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/ExperimentalSettingsFragment.kt
@@ -2,6 +2,7 @@ package com.kylecorry.trail_sense.settings.ui
 
 import android.os.Build
 import android.os.Bundle
+import androidx.preference.SwitchPreferenceCompat
 import com.kylecorry.andromeda.fragments.AndromedaPreferenceFragment
 import com.kylecorry.andromeda.sense.Sensors
 import com.kylecorry.sol.science.meteorology.forecast.ForecastSource
@@ -25,6 +26,13 @@ class ExperimentalSettingsFragment : AndromedaPreferenceFragment() {
 
         onClick(preference(R.string.pref_cliff_height_enabled)) {
             requireMainActivity().updateBottomNavigation()
+        }
+
+        onClick(switch(R.string.pref_widget_icon_compatibility)) { pref ->
+            // Refresh all widgets so the new icon rendering takes effect immediately
+            if ((pref as? SwitchPreferenceCompat)?.isChecked == true) {
+                Tools.triggerWidgetUpdate(requireContext(), null)
+            }
         }
 
         val sources = ForecastSource.entries

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
@@ -100,6 +100,12 @@ class UserPreferences(ctx: Context) : IDeclinationPreferences {
         false
     )
 
+    val useWidgetIconCompatibilityMode by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_widget_icon_compatibility),
+        false
+    )
+
     var isCliffHeightEnabled by BooleanPreference(
         cache,
         context.getString(R.string.pref_cliff_height_enabled),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/widgets/SunToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/widgets/SunToolWidgetView.kt
@@ -2,7 +2,6 @@ package com.kylecorry.trail_sense.tools.astronomy.widgets
 
 import android.content.Context
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
@@ -10,6 +9,7 @@ import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomySubsystem
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyTransition
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 
 class SunToolWidgetView : SimpleToolWidgetView() {
@@ -28,8 +28,9 @@ class SunToolWidgetView : SimpleToolWidgetView() {
                 formatService.formatTime(sun.nextRise.toLocalTime(), includeSeconds = false)
             )
             views.setTextViewText(TITLE_TEXTVIEW, context.getString(R.string.sunrise))
-            views.setImageViewResourceAsIcon(
+            WidgetHelper.setIcon(
                 context,
+                views,
                 ICON_IMAGEVIEW,
                 R.drawable.ic_sunrise_notification
             )
@@ -39,19 +40,20 @@ class SunToolWidgetView : SimpleToolWidgetView() {
                 formatService.formatTime(sun.nextSet.toLocalTime(), includeSeconds = false)
             )
             views.setTextViewText(TITLE_TEXTVIEW, context.getString(R.string.sunset))
-            views.setImageViewResourceAsIcon(
+            WidgetHelper.setIcon(
                 context,
+                views,
                 ICON_IMAGEVIEW,
                 R.drawable.ic_sunset_notification
             )
         } else if (sun.isUp) {
             views.setTextViewText(TITLE_TEXTVIEW, context.getString(R.string.sun_up_no_set))
             views.setTextViewText(SUBTITLE_TEXTVIEW, context.getString(R.string.sun_does_not_set))
-            views.setImageViewResourceAsIcon(context, ICON_IMAGEVIEW, R.drawable.ic_sun)
+            WidgetHelper.setIcon(context, views, ICON_IMAGEVIEW, R.drawable.ic_sun)
         } else {
             views.setTextViewText(TITLE_TEXTVIEW, context.getString(R.string.sun_down_no_set))
             views.setTextViewText(SUBTITLE_TEXTVIEW, context.getString(R.string.sun_does_not_rise))
-            views.setImageViewResourceAsIcon(context, ICON_IMAGEVIEW, R.drawable.ic_sun)
+            WidgetHelper.setIcon(context, views, ICON_IMAGEVIEW, R.drawable.ic_sun)
         }
         views.setOnClickPendingIntent(
             ROOT,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/flashlight/widgets/FlashlightToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/flashlight/widgets/FlashlightToolWidgetView.kt
@@ -7,12 +7,12 @@ import android.os.Build
 import android.view.View
 import android.widget.RemoteViews
 import com.kylecorry.andromeda.permissions.Permissions
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.main.MainActivity
 import com.kylecorry.trail_sense.tools.flashlight.domain.FlashlightMode
 import com.kylecorry.trail_sense.tools.flashlight.infrastructure.FlashlightSubsystem
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 
 class FlashlightToolWidgetView : SimpleToolWidgetView() {
@@ -30,8 +30,9 @@ class FlashlightToolWidgetView : SimpleToolWidgetView() {
             SUBTITLE_TEXTVIEW,
             if (isOn) context.getString(R.string.on) else context.getString(R.string.off)
         )
-        views.setImageViewResourceAsIcon(
+        WidgetHelper.setIcon(
             context,
+            views,
             ICON_IMAGEVIEW_TEXT_COLOR,
             R.drawable.flashlight
         )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/sensors/widgets/ElevationWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/sensors/widgets/ElevationWidgetView.kt
@@ -3,7 +3,6 @@ package com.kylecorry.trail_sense.tools.sensors.widgets
 import android.content.Context
 import android.view.View
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
@@ -12,6 +11,7 @@ import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.shared.sensors.LocationSubsystem
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 
 class ElevationWidgetView : SimpleToolWidgetView() {
@@ -37,8 +37,9 @@ class ElevationWidgetView : SimpleToolWidgetView() {
                 Units.getDecimalPlaces(convertedElevation.units)
             )
         )
-        views.setImageViewResourceAsIcon(
+        WidgetHelper.setIcon(
             context,
+            views,
             ICON_IMAGEVIEW_TEXT_COLOR,
             R.drawable.ic_altitude
         )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/tides/widgets/TidesToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/tides/widgets/TidesToolWidgetView.kt
@@ -2,13 +2,13 @@ package com.kylecorry.trail_sense.tools.tides.widgets
 
 import android.content.Context
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.tools.tides.subsystem.TidesSubsystem
 import com.kylecorry.trail_sense.tools.tides.ui.TideFormatter
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 
 class TidesToolWidgetView : SimpleToolWidgetView() {
@@ -21,8 +21,9 @@ class TidesToolWidgetView : SimpleToolWidgetView() {
         val formatter = TideFormatter(context)
         val tide = TidesSubsystem.getInstance(context).getNearestTide()
 
-        views.setImageViewResourceAsIcon(
+        WidgetHelper.setIcon(
             context,
+            views,
             ICON_IMAGEVIEW,
             formatter.getTideTypeImage(tide?.now?.type)
         )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/tools/widgets/WidgetHelper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/tools/widgets/WidgetHelper.kt
@@ -2,9 +2,14 @@ package com.kylecorry.trail_sense.tools.tools.widgets
 
 import android.content.Context
 import android.widget.RemoteViews
+import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
+import androidx.core.graphics.drawable.toBitmap
 import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.main.getAppService
+import com.kylecorry.trail_sense.shared.UserPreferences
 
 object WidgetHelper {
 
@@ -23,6 +28,30 @@ object WidgetHelper {
         frame.removeAllViews(R.id.widget_frame)
         frame.addView(R.id.widget_frame, child)
         return frame
+    }
+
+    /**
+     * Sets the icon of an image view in a widget.
+     *
+     * On some devices, [android.graphics.drawable.Icon.createWithResource] does not reliably
+     * render vector drawables in RemoteViews, leaving the widget icon blank. When the experimental
+     * widget icon compatibility setting is enabled, the drawable is rendered to a bitmap in the app
+     * process instead, which avoids the issue by handing the launcher a fully rasterized image.
+     */
+    fun setIcon(
+        context: Context,
+        views: RemoteViews,
+        viewId: Int,
+        @DrawableRes resourceId: Int,
+        sizeDp: Float = 32f
+    ) {
+        if (getAppService<UserPreferences>().useWidgetIconCompatibilityMode) {
+            val size = Resources.dp(context, sizeDp).toInt()
+            val bitmap = Resources.drawable(context, resourceId)?.toBitmap(size, size)
+            views.setImageViewBitmap(viewId, bitmap)
+        } else {
+            views.setImageViewResourceAsIcon(context, viewId, resourceId)
+        }
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/weather/widgets/PressureWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/weather/widgets/PressureWidgetView.kt
@@ -3,7 +3,6 @@ package com.kylecorry.trail_sense.tools.weather.widgets
 import android.content.Context
 import android.view.View
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
@@ -11,6 +10,7 @@ import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 import com.kylecorry.trail_sense.tools.weather.infrastructure.subsystem.WeatherSubsystem
 
@@ -51,8 +51,9 @@ class PressureWidgetView : SimpleToolWidgetView() {
             else -> R.drawable.ic_steady_arrow
         }
 
-        views.setImageViewResourceAsIcon(
+        WidgetHelper.setIcon(
             context,
+            views,
             ICON_IMAGEVIEW_TEXT_COLOR,
             iconRes
         )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/weather/widgets/WeatherToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/weather/widgets/WeatherToolWidgetView.kt
@@ -2,13 +2,13 @@ package com.kylecorry.trail_sense.tools.weather.widgets
 
 import android.content.Context
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.remote.setImageViewResourceAsIcon
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.tools.ui.widgets.SimpleToolWidgetView
+import com.kylecorry.trail_sense.tools.tools.widgets.WidgetHelper
 import com.kylecorry.trail_sense.tools.tools.widgets.WidgetPreferences
 import com.kylecorry.trail_sense.tools.weather.infrastructure.subsystem.WeatherSubsystem
 
@@ -37,8 +37,9 @@ class WeatherToolWidgetView : SimpleToolWidgetView() {
                 formatter.formatWeather(current.prediction.primaryHourly)
             }
         )
-        views.setImageViewResourceAsIcon(
+        WidgetHelper.setIcon(
             context,
+            views,
             ICON_IMAGEVIEW,
             formatter.getWeatherImage(current.prediction.primaryHourly)
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1440,6 +1440,9 @@
     <string name="pref_use_metal_audio" translatable="false">pref_use_metal_audio</string>
     <string name="pref_no_use_metal_vibration" translatable="false">pref_no_use_metal_vibration</string>
     <string name="smooth_gps_readings">Smooth GPS readings</string>
+    <string name="pref_widget_icon_compatibility" translatable="false">pref_widget_icon_compatibility</string>
+    <string name="widget_icon_compatibility_mode">Widget icon compatibility mode</string>
+    <string name="widget_icon_compatibility_mode_summary">Fixes missing widget icons on some devices</string>
     <plurals name="map_group_summary">
         <item quantity="one">%d map</item>
         <item quantity="other">%d maps</item>

--- a/app/src/main/res/xml/experimental_preferences.xml
+++ b/app/src/main/res/xml/experimental_preferences.xml
@@ -42,6 +42,14 @@
             app:singleLineTitle="false"
             app:title="@string/smooth_gps_readings" />
 
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_widget_icon_compatibility"
+            app:singleLineTitle="false"
+            app:summary="@string/widget_icon_compatibility_mode_summary"
+            app:title="@string/widget_icon_compatibility_mode" />
+
         <ListPreference
             app:defaultValue="1"
             app:iconSpaceReserved="false"


### PR DESCRIPTION
<!-- You are required to use this template for pull requests. Please fill out the checklist. You can optionally delete the comments. -->

## Description
<!-- DESCRIPTION: Describe here what this change does and why (not how). This will likely become the commit message body. -->
Adds a setting (default off) to render widget icons as bitmaps rather than allowing the consumer to render the resource drawable. Some manufacturers (Oppo, Android 11) decide not to properly support Android APIs and therefore can't render the vector drawables even though support was added in Android 5. This setting allows users of one of those manufacturers to get icons on Trail Sense's widgets. 

This is a somewhat speculative fix since I can't reproduce the issue, but the user reported that it was working fine for moon and maps which both use a bitmap approach and none of the resource ID approaches worked.


<!-- ISSUE: All pull requests must have an associated issue. If you don't have one, please create a post in the Discussions. Fill this out as Issue: #1234 -->
Issue: #3838 


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

