### PR TITLE
Delete step buckets/tracking periods after a configurable number of days

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/main/persistence/RepoCleanupWorker.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/persistence/RepoCleanupWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.kylecorry.andromeda.background.IPeriodicTaskScheduler
 import com.kylecorry.andromeda.background.TaskSchedulerFactory
+import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.dem.DEMRepo
 import com.kylecorry.trail_sense.shared.io.DeleteTempFilesCommand
 import com.kylecorry.trail_sense.shared.map_layers.tiles.infrastructure.persistance.CachedTileRepo
@@ -14,6 +15,7 @@ import com.kylecorry.trail_sense.tools.lightning.infrastructure.persistence.Ligh
 import com.kylecorry.trail_sense.tools.navigation.domain.NavigationBearingService
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.photo_maps.commands.MapCleanupCommand
 import com.kylecorry.trail_sense.tools.paths.infrastructure.persistence.PathService
+import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackerService
 import com.kylecorry.trail_sense.tools.weather.infrastructure.persistence.WeatherRepo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -35,7 +37,8 @@ class RepoCleanupWorker(
             LightningRepo.getInstance(context),
             DEMRepo.getInstance(),
             NavigationBearingService.getInstance(context),
-            CachedTileRepo.getInstance(context)
+            CachedTileRepo.getInstance(context),
+            getAppService<StepTrackerService>()
         )
 
         for (repo in cleanables) {

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/IPedometerPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/IPedometerPreferences.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.settings.infrastructure
 
 import com.kylecorry.sol.units.Distance
+import java.time.Duration
 
 interface IPedometerPreferences {
     var isEnabled: Boolean
@@ -8,4 +9,5 @@ interface IPedometerPreferences {
     var strideLength: Distance
     var alertDistance: Distance?
     val useAlarmForDistanceAlert: Boolean
+    var stepHistory: Duration
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PedometerPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PedometerPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.kylecorry.andromeda.preferences.BooleanPreference
 import com.kylecorry.sol.units.Distance
 import com.kylecorry.trail_sense.R
+import java.time.Duration
 
 class PedometerPreferences(context: Context) : PreferenceRepo(context), IPedometerPreferences {
     override var isEnabled by BooleanPreference(
@@ -45,4 +46,14 @@ class PedometerPreferences(context: Context) : PreferenceRepo(context), IPedomet
         getString(R.string.pref_pedometer_use_alarm_for_distance_alert),
         false
     )
+
+    override var stepHistory: Duration
+        get() {
+            val days = cache.getInt(getString(R.string.pref_pedometer_history_days)) ?: 30
+            return Duration.ofDays(days.toLong())
+        }
+        set(value) {
+            val days = value.toDays().toInt()
+            cache.putInt(getString(R.string.pref_pedometer_history_days), if (days > 0) days else 1)
+        }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/PedometerToolRegistration.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/PedometerToolRegistration.kt
@@ -5,6 +5,7 @@ import android.hardware.Sensor
 import com.kylecorry.andromeda.notify.Notify
 import com.kylecorry.andromeda.sense.Sensors
 import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.tools.pedometer.actions.PausePedometerAction
 import com.kylecorry.trail_sense.tools.pedometer.actions.ResumePedometerAction
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackerService
@@ -42,7 +43,13 @@ object PedometerToolRegistration : ToolRegistration {
             settingsNavAction = R.id.calibrateOdometerFragment,
             initialize = { PedometerSubsystem.getInstance(it) },
             singletons = listOf(
-                { StepTrackerService(StepTrackerRepo.getInstance(it), ToolEventEmitter) }
+                {
+                    StepTrackerService(
+                        StepTrackerRepo.getInstance(it),
+                        ToolEventEmitter,
+                        UserPreferences(it).pedometer
+                    )
+                }
             ),
             quickActions = listOf(
                 ToolQuickAction(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/IStepTrackerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/IStepTrackerService.kt
@@ -1,8 +1,9 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
+import com.kylecorry.trail_sense.main.persistence.ICleanable
 import java.time.Instant
 
-interface IStepTrackerService {
+interface IStepTrackerService : ICleanable {
     suspend fun getAllStepTrackingPeriods(): List<StepTrackingPeriod>
 
     suspend fun getOpenStepTrackingPeriod(): StepTrackingPeriod?

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerService.kt
@@ -1,5 +1,8 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
+import com.kylecorry.andromeda.core.time.ITimeProvider
+import com.kylecorry.andromeda.core.time.SystemTimeProvider
+import com.kylecorry.trail_sense.settings.infrastructure.IPedometerPreferences
 import com.kylecorry.trail_sense.shared.events.EventData
 import com.kylecorry.trail_sense.shared.events.IEventEmitter
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
@@ -11,7 +14,12 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-class StepTrackerService(private val repository: IStepTrackerRepository, private val eventBus: IEventEmitter) :
+class StepTrackerService(
+    private val repository: IStepTrackerRepository,
+    private val eventBus: IEventEmitter,
+    private val preferences: IPedometerPreferences,
+    private val timeProvider: ITimeProvider = SystemTimeProvider()
+) :
     IStepTrackerService {
 
     private val stepMutex = Mutex()
@@ -94,6 +102,12 @@ class StepTrackerService(private val repository: IStepTrackerRepository, private
         repository.deleteBucketsInPeriod(period.id)
         repository.deleteStepTrackingPeriod(period)
         emitStepsChanged(repository.getOpenStepTrackingPeriod()?.steps ?: 0)
+    }
+
+    override suspend fun clean() = stepMutex.withLock {
+        val cutoff = timeProvider.getTime().toInstant().minus(preferences.stepHistory)
+        repository.deleteBucketsOlderThan(cutoff)
+        repository.deleteEmptyClosedPeriods()
     }
 
     private fun emitStepsChanged(steps: Long) {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/abstractions/IStepTrackerRepository.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/abstractions/IStepTrackerRepository.kt
@@ -2,6 +2,7 @@ package com.kylecorry.trail_sense.tools.pedometer.domain.abstractions
 
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepCountBucket
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
+import java.time.Instant
 
 interface IStepTrackerRepository {
     // Step tracking periods
@@ -13,4 +14,6 @@ interface IStepTrackerRepository {
     // Step count buckets
     suspend fun upsertStepCountBucket(bucket: StepCountBucket): Long
     suspend fun deleteBucketsInPeriod(periodId: Long)
+    suspend fun deleteBucketsOlderThan(endTime: Instant)
+    suspend fun deleteEmptyClosedPeriods()
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepTrackerDao.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepTrackerDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Query
 import androidx.room.Upsert
+import java.time.Instant
 
 @Dao
 interface StepTrackerDao {
@@ -28,4 +29,14 @@ interface StepTrackerDao {
 
     @Query("DELETE FROM step_count_buckets WHERE period_id = :periodId")
     suspend fun deleteBucketsInPeriod(periodId: Long)
+
+    @Query("DELETE FROM step_count_buckets WHERE end_time < :endTime")
+    suspend fun deleteBucketsOlderThan(endTime: Instant)
+
+    @Query(
+        "DELETE FROM step_tracking_periods " +
+            "WHERE end_time IS NOT NULL " +
+            "AND _id NOT IN (SELECT DISTINCT period_id FROM step_count_buckets)"
+    )
+    suspend fun deleteEmptyClosedPeriods()
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepTrackerRepo.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepTrackerRepo.kt
@@ -6,6 +6,7 @@ import com.kylecorry.trail_sense.main.persistence.AppDatabase
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepCountBucket
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
 import com.kylecorry.trail_sense.tools.pedometer.domain.abstractions.IStepTrackerRepository
+import java.time.Instant
 
 class StepTrackerRepo private constructor(private val dao: StepTrackerDao) : IStepTrackerRepository {
 
@@ -35,6 +36,14 @@ class StepTrackerRepo private constructor(private val dao: StepTrackerDao) : ISt
 
     override suspend fun deleteBucketsInPeriod(periodId: Long) = onIO {
         dao.deleteBucketsInPeriod(periodId)
+    }
+
+    override suspend fun deleteBucketsOlderThan(endTime: Instant) = onIO {
+        dao.deleteBucketsOlderThan(endTime)
+    }
+
+    override suspend fun deleteEmptyClosedPeriods() = onIO {
+        dao.deleteEmptyClosedPeriods()
     }
 
     private suspend fun getBuckets(periodId: Long): List<StepCountBucket> {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSettingsFragment.kt
@@ -10,9 +10,11 @@ import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.luna.time.CoroutineTimer
 import com.kylecorry.andromeda.fragments.AndromedaPreferenceFragment
 import com.kylecorry.andromeda.permissions.Permissions
+import com.kylecorry.andromeda.pickers.Pickers
 import com.kylecorry.luna.concurrency.onMain
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.DistanceUtils
+import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.permissions.alertNoActivityRecognitionPermission
 import com.kylecorry.trail_sense.shared.permissions.requestActivityRecognition
@@ -23,6 +25,7 @@ import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.StepCounterService
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.subsystem.PedometerSubsystem
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
+import java.time.Duration
 
 
 class PedometerSettingsFragment : AndromedaPreferenceFragment() {
@@ -30,6 +33,7 @@ class PedometerSettingsFragment : AndromedaPreferenceFragment() {
     private lateinit var permissionPref: Preference
     private var enabledPref: SwitchPreferenceCompat? = null
     private val userPrefs by lazy { UserPreferences(requireContext()) }
+    private val formatService by lazy { FormatService.getInstance(requireContext()) }
     private val cache by lazy { PreferencesSubsystem.getInstance(requireContext()).preferences }
 
 
@@ -96,11 +100,36 @@ class PedometerSettingsFragment : AndromedaPreferenceFragment() {
             findNavController().navigate(R.id.action_calibrate_pedometer_to_estimate_stride_length)
         }
 
+        setupStepHistorySetting()
+
         setupNotificationSetting(
             getString(R.string.pref_pedometer_notification_link),
             StepCounterService.CHANNEL_ID,
             getString(R.string.pedometer)
         )
+    }
+
+    private fun setupStepHistorySetting() {
+        val stepHistory = preference(R.string.pref_pedometer_history_days)
+        stepHistory?.summary =
+            formatService.formatDays(userPrefs.pedometer.stepHistory.toDays().toInt())
+        stepHistory?.setOnPreferenceClickListener {
+            Pickers.number(
+                requireContext(),
+                it.title.toString(),
+                null,
+                userPrefs.pedometer.stepHistory.toDays().toInt(),
+                allowDecimals = false,
+                allowNegative = false,
+                hint = getString(R.string.days)
+            ) { days ->
+                if (days != null) {
+                    userPrefs.pedometer.stepHistory = Duration.ofDays(days.toLong())
+                    it.summary = formatService.formatDays(if (days.toInt() > 0) days.toInt() else 1)
+                }
+            }
+            true
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,6 +1108,8 @@
     <string name="average_speed">Average speed</string>
     <string name="steps">Steps</string>
     <string name="pref_pedometer_enabled" translatable="false">pref_pedometer_enabled</string>
+    <string name="pref_pedometer_history_days" translatable="false">pref_pedometer_history_days</string>
+    <string name="pref_pedometer_history_days_title">Step history</string>
     <string name="pref_distance_alert" translatable="false">pref_distance_alert</string>
     <string name="distance_alert">Distance alert</string>
     <string name="remove_distance_alert">Remove distance alert (%s)?</string>

--- a/app/src/main/res/xml/odometer_calibration.xml
+++ b/app/src/main/res/xml/odometer_calibration.xml
@@ -45,6 +45,12 @@
             app:key="@string/pref_odometer_reset_daily"
             app:singleLineTitle="false" />
 
+        <Preference
+            android:title="@string/pref_pedometer_history_days_title"
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_pedometer_history_days"
+            app:singleLineTitle="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:summary="@string/alarm_description"

--- a/app/src/test/java/com/kylecorry/trail_sense/settings/migrations/PedometerPreferenceMigrationTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/settings/migrations/PedometerPreferenceMigrationTest.kt
@@ -132,5 +132,8 @@ internal class PedometerPreferenceMigrationTest {
 
         override suspend fun deleteStepTrackingPeriod(period: StepTrackingPeriod) {
         }
+
+        override suspend fun clean() {
+        }
     }
 }

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerServiceTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerServiceTest.kt
@@ -1,5 +1,7 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
+import com.kylecorry.andromeda.core.time.ITimeProvider
+import com.kylecorry.trail_sense.settings.infrastructure.IPedometerPreferences
 import com.kylecorry.trail_sense.shared.events.IEventEmitter
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
 import com.kylecorry.trail_sense.tools.pedometer.domain.abstractions.IStepTrackerRepository
@@ -12,19 +14,30 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.only
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 internal class StepTrackerServiceTest {
 
     private lateinit var repository: FakeStepTrackerRepository
     private lateinit var eventBus: IEventEmitter
+    private lateinit var preferences: IPedometerPreferences
+    private lateinit var timeProvider: ITimeProvider
     private lateinit var service: StepTrackerService
 
     @BeforeEach
     fun setup() {
         repository = FakeStepTrackerRepository()
         eventBus = mock()
-        service = StepTrackerService(repository, eventBus)
+        preferences = mock()
+        timeProvider = mock()
+        whenever(preferences.stepHistory).thenReturn(Duration.ofDays(30))
+        whenever(timeProvider.getTime()).thenReturn(ZonedDateTime.ofInstant(NOW, ZoneId.of("UTC")))
+        service = StepTrackerService(repository, eventBus, preferences, timeProvider)
     }
 
     @Test
@@ -178,6 +191,44 @@ internal class StepTrackerServiceTest {
         verifyStepsChanged(0)
     }
 
+    @Test
+    fun cleanDeletesBucketsOlderThanStepHistory() = runBlocking {
+        val period = repository.addPeriod(period(id = 1, endTime = NOW))
+        val oldBucket = bucket(
+            id = 2,
+            periodId = period.id,
+            startTime = NOW.minus(Duration.ofDays(31)),
+            endTime = NOW.minus(Duration.ofDays(30)).minusSeconds(1)
+        )
+        val recentBucket = bucket(
+            id = 3,
+            periodId = period.id,
+            startTime = NOW.minus(Duration.ofDays(30)),
+            endTime = NOW.minus(Duration.ofDays(30))
+        )
+        repository.addBucket(oldBucket)
+        repository.addBucket(recentBucket)
+
+        service.clean()
+
+        assertEquals(listOf(recentBucket), repository.buckets)
+        verifyNoInteractions(eventBus)
+    }
+
+    @Test
+    fun cleanDeletesEmptyClosedPeriods() = runBlocking {
+        val emptyClosedPeriod = repository.addPeriod(period(id = 1, endTime = NOW))
+        val emptyOpenPeriod = repository.addPeriod(period(id = 2, endTime = null))
+        val nonEmptyClosedPeriod = repository.addPeriod(period(id = 3, endTime = NOW))
+        repository.addBucket(bucket(id = 4, periodId = nonEmptyClosedPeriod.id, endTime = NOW))
+
+        service.clean()
+
+        assertEquals(listOf(emptyClosedPeriod), repository.deletedPeriods)
+        assertEquals(listOf(emptyOpenPeriod, nonEmptyClosedPeriod), repository.periods)
+        verifyNoInteractions(eventBus)
+    }
+
     private fun verifyStepsChanged(steps: Long) {
         verify(eventBus, only()).broadcast(
             eq(PedometerToolRegistration.BROADCAST_STEPS_CHANGED),
@@ -258,6 +309,18 @@ internal class StepTrackerServiceTest {
             deletedBucketPeriodIds.add(periodId)
         }
 
+        override suspend fun deleteBucketsOlderThan(endTime: Instant) {
+            buckets.removeAll { it.endTime.isBefore(endTime) }
+        }
+
+        override suspend fun deleteEmptyClosedPeriods() {
+            val emptyClosedPeriods = periods.filter { period ->
+                period.endTime != null && buckets.none { it.periodId == period.id }
+            }
+            periods.removeAll(emptyClosedPeriods)
+            deletedPeriods.addAll(emptyClosedPeriods)
+        }
+
         fun addPeriod(period: StepTrackingPeriod): StepTrackingPeriod {
             periods.add(period.copy(stepCountBuckets = emptyList()))
             nextId = maxOf(nextId, period.id + 1)
@@ -273,6 +336,10 @@ internal class StepTrackerServiceTest {
         private fun StepTrackingPeriod.withBuckets(): StepTrackingPeriod {
             return copy(stepCountBuckets = buckets.filter { it.periodId == id })
         }
+    }
+
+    companion object {
+        private val NOW = Instant.parse("2026-06-14T12:00:00Z")
     }
 
 }


### PR DESCRIPTION
Deletes step buckets after a configurable number of days (default 30) and empty closed step tracking periods during the repo cleanup process.

Issue: #1397


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator

## Screenshots
<!-- Add screenshots or video to help explain your changes (if applicable) -->

