### PR TITLE
Add pedometer session history button and dialog

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import com.kylecorry.andromeda.alerts.Alerts
 import com.kylecorry.andromeda.core.math.DecimalFormatter
@@ -32,12 +33,12 @@ import com.kylecorry.trail_sense.shared.permissions.requestActivityRecognition
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
 import com.kylecorry.trail_sense.tools.pedometer.domain.HourlyStepCount
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackerService
+import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
 import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.AveragePaceSpeedometer
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.CurrentPaceSpeedometer
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.subsystem.PedometerSubsystem
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
-import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 
@@ -78,6 +79,7 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
         setupPedometerPlayBar()
         setupDistanceAlertButton()
         setupHourlyStepsDatePicker()
+        setupPedometerSessionsButton()
 
         observe(averageSpeedometer) { onUpdate() }
 
@@ -161,6 +163,12 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
         }
     }
 
+    private fun setupPedometerSessionsButton() {
+        binding.pedometerSessionsBtn.setOnClickListener {
+            showPedometerSessions()
+        }
+    }
+
     override fun onResume() {
         super.onResume()
         Tools.subscribe(PedometerToolRegistration.BROADCAST_STEPS_CHANGED, ::updateSteps)
@@ -173,10 +181,61 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
     }
 
     private suspend fun updateSteps(data: Bundle?) {
-        val trackingPeriod = stepTrackerService.getOpenStepTrackingPeriod() ?: return
-        steps = data?.getLong(PedometerToolRegistration.BROADCAST_PARAM_STEPS) ?: trackingPeriod.steps
-        lastResetTime = trackingPeriod.startTime
+        val trackingPeriod = stepTrackerService.getOpenStepTrackingPeriod()
+        steps = data?.getLong(PedometerToolRegistration.BROADCAST_PARAM_STEPS)
+            ?: trackingPeriod?.steps
+                    ?: 0L
+        lastResetTime = trackingPeriod?.startTime
         updateHourlySteps()
+    }
+
+    private fun showPedometerSessions() {
+        inBackground {
+            val periods = stepTrackerService.getAllStepTrackingPeriods()
+                .sortedByDescending { it.startTime }
+            onMain {
+                var dialog: AlertDialog? = null
+                val mapper = PedometerSessionListItemMapper(
+                    requireContext(),
+                    paceCalculator
+                ) { period, title ->
+                    confirmDeletePedometerSession(
+                        period,
+                        title,
+                        dialog
+                    )
+                }
+                dialog = CustomUiUtils.showList(
+                    requireContext(),
+                    getString(R.string.history),
+                    periods.map(mapper::map),
+                    emptyText = getString(R.string.no_pedometer_sessions)
+                )
+            }
+        }
+    }
+
+    private fun confirmDeletePedometerSession(
+        period: StepTrackingPeriod,
+        title: String,
+        dialog: AlertDialog?
+    ) {
+        Alerts.dialog(
+            requireContext(),
+            getString(R.string.delete),
+            title
+        ) { cancelled ->
+            if (!cancelled) {
+                inBackground {
+                    stepTrackerService.deleteStepTrackingPeriod(period)
+                    onMain {
+                        // Refresh the dialog
+                        dialog?.dismiss()
+                        showPedometerSessions()
+                    }
+                }
+            }
+        }
     }
 
     private suspend fun updateHourlySteps() {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
@@ -1,0 +1,77 @@
+package com.kylecorry.trail_sense.tools.pedometer.ui
+
+import android.content.Context
+import com.kylecorry.andromeda.core.math.DecimalFormatter
+import com.kylecorry.andromeda.views.list.ListItem
+import com.kylecorry.andromeda.views.list.ListItemMapper
+import com.kylecorry.andromeda.views.list.ListMenuItem
+import com.kylecorry.sol.time.Time.toZonedDateTime
+import com.kylecorry.sol.units.DistanceUnits
+import com.kylecorry.sol.units.TimeUnits
+import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.main.getAppService
+import com.kylecorry.trail_sense.shared.DistanceUtils.toRelativeDistance
+import com.kylecorry.trail_sense.shared.FormatService
+import com.kylecorry.trail_sense.shared.Units
+import com.kylecorry.trail_sense.shared.UserPreferences
+import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
+import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
+import java.time.Duration
+import java.time.Instant
+
+class PedometerSessionListItemMapper(
+    private val context: Context,
+    private val paceCalculator: StrideLengthPaceCalculator,
+    private val onDelete: (period: StepTrackingPeriod, title: String) -> Unit
+) : ListItemMapper<StepTrackingPeriod> {
+
+    private val formatter = getAppService<FormatService>()
+    private val prefs = getAppService<UserPreferences>()
+
+    override fun map(value: StepTrackingPeriod): ListItem {
+        val title = getTitle(value)
+        return ListItem(
+            value.id,
+            title,
+            subtitle = getSubtitle(value),
+            menu = listOf(
+                ListMenuItem(context.getString(R.string.delete)) {
+                    onDelete(value, title)
+                }
+            )
+        )
+    }
+
+    private fun getTitle(period: StepTrackingPeriod): String {
+        val endTime = period.endTime ?: Instant.now()
+        return formatter.formatTimeSpan(
+            period.startTime.toZonedDateTime(),
+            endTime.toZonedDateTime(),
+            relative = true
+        )
+    }
+
+    private fun getSubtitle(period: StepTrackingPeriod): String {
+        val duration = Duration.between(period.startTime, period.endTime ?: Instant.now())
+        val distance = paceCalculator.distance(period.steps)
+            .convertTo(prefs.baseDistanceUnits)
+            .toRelativeDistance()
+        val speed = paceCalculator.speed(period.steps, duration)
+            .convertTo(DistanceUnits.Meters, TimeUnits.Seconds)
+        return formatter.join(
+            DecimalFormatter.format(period.steps, 0) + " " + context.getString(R.string.steps),
+            formatter.formatDistance(
+                distance,
+                Units.getDecimalPlaces(distance.units),
+                false
+            ),
+            if (duration.seconds > 0) {
+                formatter.formatSpeed(speed.value)
+            } else {
+                context.getString(R.string.dash)
+            },
+            formatter.formatDuration(duration, short = true),
+            separator = FormatService.Separator.Dot
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_tool_pedometer.xml
+++ b/app/src/main/res/layout/fragment_tool_pedometer.xml
@@ -101,13 +101,29 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/reset" />
 
-            <TextView
-                android:id="@+id/history_title"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                android:text="@string/history"
-                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/history_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/history"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/pedometer_sessions_btn"
+                    style="@style/Widget.Material3.Button.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/history"
+                    app:icon="@drawable/ic_tool_clock" />
+
+            </LinearLayout>
 
             <com.kylecorry.trail_sense.shared.views.DatePickerView
                 android:id="@+id/hourly_steps_date"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1158,6 +1158,7 @@
     <string name="tide_frequency_description">The number of high tides per day. Most tides are semidiurnal.</string>
     <string name="current_session">Current session</string>
     <string name="history">History</string>
+    <string name="no_pedometer_sessions">No sessions</string>
     <string name="permission_alarms_and_reminders">Alarms and reminders</string>
     <string name="change_resolution">Change resolution</string>
     <string name="done">Done</string>


### PR DESCRIPTION
Adds a pedometer tracking session history list button to the pedometer fragment. When clicked it opens the list in a dialog and allows for the deletion of sessions.

Issue: #1397 


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
