### PR TITLE
Render accurate lunar eclipse icons

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -353,6 +353,7 @@
     <ID>ReturnCount:FormatService.kt:FormatService$fun formatWeatherArrival: String</ID>
     <ID>ReturnCount:FrequencyHookTrigger.kt:FrequencyHookTrigger$fun getValue: Boolean</ID>
     <ID>ReturnCount:GeographicImageUtils.kt:GeographicImageUtils$suspend fun getNearestPixelOfAsset: PixelCoordinate?</ID>
+    <ID>ReturnCount:HillshadeMapTileSource.kt:HillshadeMapTileSource$private fun getShadowConfig: Pair&lt;Float, Float&gt;</ID>
     <ID>ReturnCount:MainActivity.kt:MainActivity$override fun onKeyDown: Boolean</ID>
     <ID>ReturnCount:MainActivity.kt:MainActivity$override fun onKeyUp: Boolean</ID>
     <ID>ReturnCount:MainActivity.kt:MainActivity$private fun getVolumeAction: VolumeAction?</ID>

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/camera/AugmentedRealityUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/camera/AugmentedRealityUtils.kt
@@ -7,7 +7,6 @@ import com.kylecorry.andromeda.sense.orientation.IOrientationSensor
 import com.kylecorry.andromeda.sense.orientation.OrientationUtils
 import com.kylecorry.sol.math.MathExtensions.toDegrees
 import com.kylecorry.sol.math.MathExtensions.toRadians
-import com.kylecorry.sol.math.Vector2
 import com.kylecorry.sol.math.Vector3
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.math.trigonometry.Trigonometry
@@ -71,38 +70,6 @@ object AugmentedRealityUtils {
 
     fun getAngularSize(diameterMeters: Float, distanceMeters: Float): Float {
         return (2 * atan2(diameterMeters / 2f, distanceMeters)).toDegrees()
-    }
-
-    /**
-     * Gets the angular offset of a point from a view centered at the given bearing/elevation.
-     * Positive x is right of center and positive y is above center.
-     */
-    fun getAngularOffset(
-        centerBearing: Float,
-        centerElevation: Float,
-        pointBearing: Float,
-        pointElevation: Float
-    ): Vector2 {
-        val point = toEastNorthUp(pointBearing, pointElevation, 1f)
-
-        val centerBearingRad = centerBearing.toRadians()
-        val centerElevationRad = centerElevation.toRadians()
-        val cosCenterElevation = cos(centerElevationRad)
-        val sinCenterElevation = sin(centerElevationRad)
-        val cosCenterBearing = cos(centerBearingRad)
-        val sinCenterBearing = sin(centerBearingRad)
-
-        val forward = point.x * cosCenterElevation * sinCenterBearing +
-            point.y * cosCenterElevation * cosCenterBearing +
-            point.z * sinCenterElevation
-        val right = point.x * cosCenterBearing -
-            point.y * sinCenterBearing
-        val up = -point.x * sinCenterElevation * sinCenterBearing -
-            point.y * sinCenterElevation * cosCenterBearing +
-            point.z * cosCenterElevation
-
-        val spherical = CameraAnglePixelMapper.toSpherical(Vector3(right, up, forward))
-        return Vector2(spherical.z, spherical.y)
     }
 
     /**

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/dem/map_layers/HillshadeMapTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/dem/map_layers/HillshadeMapTileSource.kt
@@ -1,7 +1,6 @@
 package com.kylecorry.trail_sense.shared.dem.map_layers
 
 import android.content.Context
-
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
@@ -19,8 +18,8 @@ import com.kylecorry.trail_sense.shared.dem.getSlopeAngle
 import com.kylecorry.trail_sense.shared.dem.getSlopeAspect
 import com.kylecorry.trail_sense.shared.dem.getSlopeVector
 import com.kylecorry.trail_sense.shared.map_layers.tiles.Tile
-import com.kylecorry.trail_sense.shared.map_layers.ui.layers.getPreferences
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.MapLayerParams
+import com.kylecorry.trail_sense.shared.map_layers.ui.layers.getPreferences
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
 import java.time.Instant
@@ -124,11 +123,9 @@ class HillshadeMapTileSource : TileSource {
             return 315f to 45f
         }
 
-        if (astronomy.getSunAltitude(location, time) > AstronomyService.SUN_MIN_ALTITUDE_CIVIL) {
-            return astronomy.getSunAzimuth(location, time).value to astronomy.getSunAltitude(
-                location,
-                time
-            )
+        val sunPosition = astronomy.getSunPosition(location, time)
+        if (sunPosition.altitude > AstronomyService.SUN_MIN_ALTITUDE_CIVIL) {
+            return sunPosition.azimuth.value to sunPosition.altitude
         }
 
         if (astronomy.isMoonUp(
@@ -136,10 +133,9 @@ class HillshadeMapTileSource : TileSource {
                 time
             ) && Astronomy.getMoonPhase(time).illumination > 0.25f
         ) {
-            return astronomy.getMoonAzimuth(location, time).value to astronomy.getMoonAltitude(
-                location,
-                time
-            )
+            val position = astronomy.getMoonPosition(location, time)
+
+            return position.azimuth.value to position.altitude
         }
 
         return 315f to 45f

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
@@ -6,6 +6,7 @@ import com.kylecorry.sol.science.astronomy.Astronomy
 import com.kylecorry.sol.science.astronomy.RiseSetTransitTimes
 import com.kylecorry.sol.science.astronomy.SunTimesMode
 import com.kylecorry.sol.science.astronomy.eclipse.EclipseType
+import com.kylecorry.sol.science.astronomy.eclipse.LunarEclipseShadow
 import com.kylecorry.sol.science.astronomy.locators.Planet
 import com.kylecorry.sol.science.astronomy.meteors.MeteorShower
 import com.kylecorry.sol.science.astronomy.meteors.MeteorShowerPeak
@@ -78,7 +79,7 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             endTime,
             altitudeGranularity
         ) {
-            getMoonAltitude(location, it)
+            getMoonPosition(location, it).altitude
         }
     }
 
@@ -88,16 +89,15 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             ZoneId.systemDefault(),
             altitudeGranularity
         ) {
-            getMoonAltitude(location, it)
+            getMoonPosition(location, it).altitude
         }
     }
 
-    fun getMoonAltitude(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now()): Float {
-        return Astronomy.getMoonAltitude(time, location, withRefraction = true, withParallax = true)
-    }
-
-    fun getMoonAzimuth(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now()): Bearing {
-        return Astronomy.getMoonAzimuth(time, location, withParallax = true)
+    fun getMoonPosition(
+        location: Coordinate,
+        time: ZonedDateTime = ZonedDateTime.now()
+    ): CelestialObservation {
+        return Astronomy.getMoonPosition(time, location, withRefraction = true, withParallax = true)
     }
 
     fun isMoonUp(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now(clock)): Boolean {
@@ -134,13 +134,6 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
 
 
         return Astronomy.getMoonParallacticAngle(timeToUse, location)
-    }
-
-    fun getMoonAngularDiameter(
-        location: Coordinate,
-        time: ZonedDateTime = ZonedDateTime.now(clock)
-    ): Float {
-        return Astronomy.getMoonAngularDiameter(time, location).toFloat()
     }
 
     // PUBLIC SUN METHODS
@@ -185,7 +178,7 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             ZoneId.systemDefault(),
             altitudeGranularity
         ) {
-            getSunAltitude(location, it)
+            getSunPosition(location, it).altitude
         }
     }
 
@@ -200,7 +193,7 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             endTime,
             altitudeGranularity
         ) {
-            getSunAltitude(location, it)
+            getSunPosition(location, it).altitude
         }
     }
 
@@ -226,12 +219,11 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
         return Astronomy.isSunUp(time, location, true)
     }
 
-    fun getSunAzimuth(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now()): Bearing {
-        return Astronomy.getSunAzimuth(time, location)
-    }
-
-    fun getSunAltitude(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now()): Float {
-        return Astronomy.getSunAltitude(time, location, true)
+    fun getSunPosition(
+        location: Coordinate,
+        time: ZonedDateTime = ZonedDateTime.now()
+    ): CelestialObservation {
+        return Astronomy.getSunPosition(time, location)
     }
 
     fun getSunAboveHorizonTimes(location: Coordinate, time: ZonedDateTime): Range<ZonedDateTime>? {
@@ -239,12 +231,6 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             location, time,
             withRefraction = true
         )
-    }
-
-    fun getSunAngularDiameter(
-        time: ZonedDateTime = ZonedDateTime.now(clock)
-    ): Float {
-        return Astronomy.getSunAngularDiameter(time).toFloat()
     }
 
     fun getMeteorShower(
@@ -257,20 +243,12 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
         return todays ?: tomorrows
     }
 
-    fun getMeteorShowerPeakAltitude(peak: MeteorShowerPeak, location: Coordinate): Float {
+    fun getMeteorShowerPeakPosition(peak: MeteorShowerPeak, location: Coordinate): CelestialObservation {
         return Astronomy.getMeteorShowerPosition(
             peak.shower,
             location,
             peak.peak.toInstant()
-        ).altitude
-    }
-
-    fun getMeteorShowerPeakAzimuth(peak: MeteorShowerPeak, location: Coordinate): Bearing {
-        return Astronomy.getMeteorShowerPosition(
-            peak.shower,
-            location,
-            peak.peak.toInstant()
-        ).azimuth
+        )
     }
 
     fun getSeason(location: Coordinate, date: LocalDate = LocalDate.now()): Season {
@@ -285,8 +263,13 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
         date: LocalDate = LocalDate.now()
     ): Eclipse? {
         return getEclipse(location, date, EclipseType.PartialLunar) {
-            getMoonAzimuth(location, it) to getMoonAltitude(location, it)
+            val moon = getMoonPosition(location, it)
+            moon.azimuth to moon.altitude
         }
+    }
+
+    fun getLunarEclipseShadow(location: Coordinate, time: ZonedDateTime = ZonedDateTime.now()): LunarEclipseShadow {
+        return Astronomy.getLunarEclipseShadow(time, location, withRefraction = true, withParallax = true)
     }
 
     fun getSolarEclipse(
@@ -294,7 +277,8 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
         date: LocalDate = LocalDate.now()
     ): Eclipse? {
         return getEclipse(location, date, EclipseType.Solar, 1) {
-            getSunAzimuth(location, it) to getSunAltitude(location, it)
+            val sun = getSunPosition(location, it)
+            sun.azimuth to sun.altitude
         }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomySubsystem.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomySubsystem.kt
@@ -30,8 +30,7 @@ class AstronomySubsystem(context: Context) {
             val sunTimesMode = prefs.astronomy.sunTimesMode
             val location = location.location
             val times = astronomyService.getSunTimes(location, sunTimesMode, LocalDate.now())
-            val azimuth = astronomyService.getSunAzimuth(location)
-            val altitude = astronomyService.getSunAltitude(location)
+            val position = astronomyService.getSunPosition(location)
 
             val nextSunrise = astronomyService.getNextSunrise(location, sunTimesMode)
             val nextSunset = astronomyService.getNextSunset(location, sunTimesMode)
@@ -40,11 +39,11 @@ class AstronomySubsystem(context: Context) {
                 times.rise?.toLocalDateTime(),
                 times.set?.toLocalDateTime(),
                 times.transit?.toLocalDateTime(),
-                altitude > 0,
+                position.altitude > 0,
                 nextSunrise,
                 nextSunset,
-                altitude,
-                azimuth
+                position.altitude,
+                position.azimuth
             )
         }
 
@@ -57,20 +56,19 @@ class AstronomySubsystem(context: Context) {
             val location = location.location
             val moonTimes = astronomyService.getMoonTimes(location, LocalDate.now())
             val phase = astronomyService.getCurrentMoonPhase()
-            val altitude = astronomyService.getMoonAltitude(location)
-            val azimuth = astronomyService.getMoonAzimuth(location)
+            val position = astronomyService.getMoonPosition(location)
             val tilt = astronomyService.getMoonTilt(location)
 
             MoonDetails(
                 moonTimes.rise?.toLocalDateTime(),
                 moonTimes.set?.toLocalDateTime(),
                 moonTimes.transit?.toLocalDateTime(),
-                altitude > 0,
+                position.altitude > 0,
                 phase.phase,
                 phase.phaseAngle,
                 phase.illumination,
-                altitude,
-                azimuth,
+                position.altitude,
+                position.azimuth,
                 tilt
             )
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/map_layers/NightTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/map_layers/NightTileSource.kt
@@ -44,7 +44,7 @@ class NightTileSource : TileSource {
             bounds.northEast,
             bounds.southEast
         ).any {
-            astronomy.getSunAltitude(it, time) < 1
+            astronomy.getSunPosition(it, time).altitude < 1
         }
 
         if (!isNight) {
@@ -61,7 +61,7 @@ class NightTileSource : TileSource {
             valueProvider = InterpolatedGridValueProvider(
                 10,
                 ParallelCoordinateGridValueProvider { lat, lon ->
-                    astronomy.getSunAltitude(Coordinate(lat, lon), time)
+                    astronomy.getSunPosition(Coordinate(lat, lon), time).altitude
                 })
         ) { x, y, getValue ->
             val value = getValue(x, y)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyDayViewDecorator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyDayViewDecorator.kt
@@ -5,7 +5,6 @@ import android.graphics.drawable.Drawable
 import androidx.core.graphics.drawable.toDrawable
 import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.andromeda.pickers.material.AndromedaDayViewDecorator
-import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
@@ -17,6 +16,7 @@ class AstronomyDayViewDecorator(private val location: Coordinate) : AndromedaDay
 
     private var phaseImageMapper: MoonPhaseImageMapper? = null
     private var solarEclipseImageMapper: SolarEclipseImageMapper? = null
+    private var lunarEclipseImageMapper: LunarEclipseImageMapper? = null
 
     override fun getBottomDrawable(
         context: Context,
@@ -35,8 +35,8 @@ class AstronomyDayViewDecorator(private val location: Coordinate) : AndromedaDay
             )
         val hasMeteorShower = astronomy.getMeteorShower(location, date) != null
         val lunarEclipse = astronomy.getLunarEclipse(location, date)
-        val hasPartialLunar = lunarEclipse != null && !lunarEclipse.isTotal
-        val hasTotalLunar = lunarEclipse?.isTotal == true
+        val lunarEclipseDrawable =
+            lunarEclipse?.let { getLunarEclipseDrawable(context, astronomy, it, size) }
         val solarEclipse = astronomy.getSolarEclipse(location, date)
         val solarEclipseDrawable =
             solarEclipse?.let { getSolarEclipseDrawable(context, astronomy, it, size) }
@@ -53,16 +53,7 @@ class AstronomyDayViewDecorator(private val location: Coordinate) : AndromedaDay
                 size,
                 Resources.androidTextColorSecondary(context)
             ) else null,
-            if (hasTotalLunar) createIndicatorDrawable(
-                context,
-                R.drawable.ic_moon_total_eclipse,
-                size
-            ) else null,
-            if (hasPartialLunar) createIndicatorDrawable(
-                context,
-                R.drawable.ic_moon_partial_eclipse,
-                size
-            ) else null,
+            lunarEclipseDrawable,
             solarEclipseDrawable
         )
 
@@ -79,20 +70,30 @@ class AstronomyDayViewDecorator(private val location: Coordinate) : AndromedaDay
         eclipse: Eclipse,
         size: Int
     ): Drawable {
-        val sunAzimuth = astronomy.getSunAzimuth(location, eclipse.peak)
-        val sunAltitude = astronomy.getSunAltitude(location, eclipse.peak)
-        val moonAzimuth = astronomy.getMoonAzimuth(location, eclipse.peak)
-        val moonAltitude = astronomy.getMoonAltitude(location, eclipse.peak)
+        val sun = astronomy.getSunPosition(location, eclipse.peak)
+        val moon = astronomy.getMoonPosition(location, eclipse.peak)
         return getSolarEclipseImageMapper(context).getEclipseImage(
-            CelestialObservation(sunAzimuth, sunAltitude, astronomy.getSunAngularDiameter(eclipse.peak)),
-            CelestialObservation(
-                moonAzimuth,
-                moonAltitude,
-                astronomy.getMoonAngularDiameter(location, eclipse.peak)
-            ),
+            sun,
+            moon,
             eclipse.isTotal,
             size,
             size
+        ).toDrawable(context.resources).apply { setBounds(0, 0, size, size) }
+    }
+
+    private fun getLunarEclipseDrawable(
+        context: Context,
+        astronomy: AstronomyService,
+        eclipse: Eclipse,
+        size: Int
+    ): Drawable {
+        val moon = astronomy.getMoonPosition(location, eclipse.peak)
+        return getLunarEclipseImageMapper(context).getEclipseImage(
+            moon,
+            astronomy.getLunarEclipseShadow(location, eclipse.peak),
+            size,
+            size,
+            astronomy.getMoonTilt(location, eclipse.peak)
         ).toDrawable(context.resources).apply { setBounds(0, 0, size, size) }
     }
 
@@ -106,6 +107,13 @@ class AstronomyDayViewDecorator(private val location: Coordinate) : AndromedaDay
         return solarEclipseImageMapper
             ?: SolarEclipseImageMapper(context.applicationContext).also {
                 solarEclipseImageMapper = it
+            }
+    }
+
+    private fun getLunarEclipseImageMapper(context: Context): LunarEclipseImageMapper {
+        return lunarEclipseImageMapper
+            ?: LunarEclipseImageMapper(context.applicationContext).also {
+                lunarEclipseImageMapper = it
             }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyFragment.kt
@@ -11,14 +11,14 @@ import com.kylecorry.andromeda.alerts.Alerts
 import com.kylecorry.andromeda.alerts.toast
 import com.kylecorry.andromeda.core.cache.AppServiceRegistry
 import com.kylecorry.andromeda.core.system.Resources
-import com.kylecorry.luna.text.capitalizeWords
-import com.kylecorry.luna.concurrency.onDefault
-import com.kylecorry.luna.concurrency.onMain
 import com.kylecorry.andromeda.fragments.BoundFragment
 import com.kylecorry.andromeda.fragments.inBackground
 import com.kylecorry.andromeda.markdown.MarkdownService
 import com.kylecorry.andromeda.pickers.Pickers
 import com.kylecorry.andromeda.sense.location.IGPS
+import com.kylecorry.luna.concurrency.onDefault
+import com.kylecorry.luna.concurrency.onMain
+import com.kylecorry.luna.text.capitalizeWords
 import com.kylecorry.sol.science.astronomy.SunTimesMode
 import com.kylecorry.sol.time.Time.atEndOfDay
 import com.kylecorry.sol.time.Time.toZonedDateTime
@@ -287,19 +287,18 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
     }
 
     private fun getSunMoonPositions(time: ZonedDateTime): AstroPositions {
-        val moonAltitude = astronomyService.getMoonAltitude(location, time)
-        val sunAltitude = astronomyService.getSunAltitude(location, time)
-
+        val moonPosition = astronomyService.getMoonPosition(location, time)
+        val sunPosition = astronomyService.getSunPosition(location, time)
         val declination = if (!prefs.compass.useTrueNorth) getDeclination() else 0f
 
         val sunAzimuth =
-            astronomyService.getSunAzimuth(location, time).withDeclination(-declination).value
+            sunPosition.azimuth.withDeclination(-declination).value
         val moonAzimuth =
-            astronomyService.getMoonAzimuth(location, time).withDeclination(-declination).value
+            moonPosition.azimuth.withDeclination(-declination).value
 
         return AstroPositions(
-            moonAltitude,
-            sunAltitude,
+            moonPosition.altitude,
+            sunPosition.altitude,
             moonAzimuth,
             sunAzimuth
         )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/LunarEclipseImageMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/LunarEclipseImageMapper.kt
@@ -1,0 +1,85 @@
+package com.kylecorry.trail_sense.tools.astronomy.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Path
+import androidx.core.graphics.createBitmap
+import com.kylecorry.andromeda.canvas.CanvasDrawer
+import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.sol.math.trigonometry.Trigonometry
+import com.kylecorry.sol.science.astronomy.eclipse.LunarEclipseShadow
+import com.kylecorry.sol.science.astronomy.units.CelestialObservation
+import com.kylecorry.trail_sense.R
+
+class LunarEclipseImageMapper(private val context: Context) {
+
+    private val moonDrawable by lazy {
+        Resources.drawable(context, R.drawable.ic_moon)
+    }
+
+    fun getEclipseImage(
+        moon: CelestialObservation,
+        shadow: LunarEclipseShadow,
+        width: Int,
+        height: Int,
+        tilt: Float? = null
+    ): Bitmap {
+        val output = createBitmap(width, height)
+        val canvas = Canvas(output)
+        val drawer = CanvasDrawer(context, canvas)
+        drawer.push()
+        tilt?.let {
+            drawer.rotate(it, width / 2f, height / 2f)
+        }
+        moonDrawable?.let {
+            it.setBounds(0, 0, width, height)
+            it.draw(canvas)
+        }
+
+        val shadowOffset = Trigonometry.getAngularOffset(
+            moon.azimuth.value,
+            moon.altitude,
+            shadow.umbra.azimuth.value,
+            shadow.umbra.altitude
+        )
+        val moonAngularDiameter = moon.angularDiameter ?: 0.5f
+        val umbraAngularDiameter = shadow.umbra.angularDiameter ?: 0.5f
+        val penumbraAngularDiameter = shadow.penumbra.angularDiameter ?: umbraAngularDiameter
+        val scale = minOf(width, height) / moonAngularDiameter
+        val centerX = width / 2f
+        val centerY = height / 2f
+        val shadowCenterX = centerX + shadowOffset.x * scale
+        val shadowCenterY = centerY - shadowOffset.y * scale
+        val umbraRadius = umbraAngularDiameter / 2f * scale
+        val penumbraRadius = penumbraAngularDiameter / 2f * scale
+
+        val moonClip = Path().apply {
+            addCircle(
+                centerX,
+                centerY,
+                minOf(width, height) / 2f + CLIP_BUFFER_PIXELS,
+                Path.Direction.CW
+            )
+        }
+        drawer.noStroke()
+        drawer.push()
+        drawer.clip(moonClip)
+        drawer.fill(SHADOW_COLOR)
+        drawer.opacity(PENUMBRA_ALPHA)
+        drawer.circle(shadowCenterX, shadowCenterY, penumbraRadius * 2f)
+        drawer.opacity(255)
+        drawer.fill(SHADOW_COLOR)
+        drawer.circle(shadowCenterX, shadowCenterY, umbraRadius * 2f)
+        drawer.pop()
+        drawer.pop()
+
+        return output
+    }
+
+    companion object {
+        private const val SHADOW_COLOR = 0x80FF6D00.toInt()
+        private const val CLIP_BUFFER_PIXELS = 0.5f
+        private const val PENUMBRA_ALPHA = 32
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/SolarEclipseImageMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/SolarEclipseImageMapper.kt
@@ -8,9 +8,9 @@ import android.graphics.Path
 import androidx.core.graphics.createBitmap
 import com.kylecorry.andromeda.canvas.CanvasDrawer
 import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.sol.math.trigonometry.Trigonometry
 import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.trail_sense.R
-import com.kylecorry.trail_sense.shared.camera.AugmentedRealityUtils
 
 class SolarEclipseImageMapper(private val context: Context) {
 
@@ -24,7 +24,7 @@ class SolarEclipseImageMapper(private val context: Context) {
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
         val drawer = CanvasDrawer(context, canvas)
-        val moonOffset = AugmentedRealityUtils.getAngularOffset(
+        val moonOffset = Trigonometry.getAngularOffset(
             sun.azimuth.value,
             sun.altitude,
             moon.azimuth.value,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/LunarEclipseListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/LunarEclipseListItemProducer.kt
@@ -1,13 +1,17 @@
 package com.kylecorry.trail_sense.tools.astronomy.ui.items
 
 import android.content.Context
-import com.kylecorry.luna.concurrency.onDefault
+import androidx.core.graphics.drawable.toDrawable
 import com.kylecorry.andromeda.core.math.DecimalFormatter
+import com.kylecorry.andromeda.views.list.DrawableListIcon
 import com.kylecorry.andromeda.views.list.ListItem
-import com.kylecorry.andromeda.views.list.ResourceListIcon
+import com.kylecorry.luna.concurrency.onDefault
+import com.kylecorry.sol.science.astronomy.eclipse.LunarEclipseShadow
+import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.declination.DeclinationUtils
+import com.kylecorry.trail_sense.tools.astronomy.ui.LunarEclipseImageMapper
 import com.kylecorry.trail_sense.tools.astronomy.ui.format.EclipseFormatter
 import java.time.LocalDate
 
@@ -21,23 +25,19 @@ class LunarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
         val eclipse = astronomyService.getLunarEclipse(location, date) ?: return@onDefault null
 
         // Advanced
-        val peakAltitude = astronomyService.getMoonAltitude(location, eclipse.peak)
+        val moon = astronomyService.getMoonPosition(location, eclipse.peak)
         val peakAzimuth = DeclinationUtils.fromTrueNorthBearing(
-            astronomyService.getMoonAzimuth(location, eclipse.peak),
+            moon.azimuth,
             declination
         )
+        val shadow = astronomyService.getLunarEclipseShadow(location, eclipse.peak)
+        val moonTilt = astronomyService.getMoonTilt(location, eclipse.peak)
 
         list(
             4,
             context.getString(R.string.lunar_eclipse),
             EclipseFormatter.type(context, eclipse),
-            ResourceListIcon(
-                if (eclipse.isTotal) {
-                    R.drawable.ic_moon_total_eclipse
-                } else {
-                    R.drawable.ic_moon_partial_eclipse
-                }
-            ),
+            getIcon(moon, shadow, moonTilt),
             data = times(eclipse.start, eclipse.peak, eclipse.end, date)
         ) {
             val advancedData = listOf(
@@ -67,7 +67,7 @@ class LunarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
                 ),
                 context.getString(R.string.astronomy_altitude_peak) to data(
                     formatter.formatDegrees(
-                        peakAltitude
+                        moon.altitude
                     )
                 ),
                 context.getString(R.string.astronomy_direction_peak) to data(
@@ -81,5 +81,20 @@ class LunarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
         }
     }
 
+    private fun getIcon(
+        moon: CelestialObservation,
+        shadow: LunarEclipseShadow,
+        moonTilt: Float
+    ): DrawableListIcon {
+        return DrawableListIcon(
+            LunarEclipseImageMapper(context).getEclipseImage(
+                moon,
+                shadow,
+                imageSize,
+                imageSize,
+                moonTilt
+            ).toDrawable(context.resources)
+        )
+    }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/MeteorShowerListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/MeteorShowerListItemProducer.kt
@@ -1,9 +1,9 @@
 package com.kylecorry.trail_sense.tools.astronomy.ui.items
 
 import android.content.Context
-import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.views.list.ListItem
 import com.kylecorry.andromeda.views.list.ResourceListIcon
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.declination.DeclinationUtils
@@ -20,9 +20,10 @@ class MeteorShowerListItemProducer(context: Context) : BaseAstroListItemProducer
         val shower = astronomyService.getMeteorShower(location, date) ?: return@onDefault null
 
         // Advanced
-        val peakAltitude = astronomyService.getMeteorShowerPeakAltitude(shower, location)
+        val peakPosition = astronomyService.getMeteorShowerPeakPosition(shower, location)
+        val peakAltitude = peakPosition.altitude
         val peakAzimuth = DeclinationUtils.fromTrueNorthBearing(
-            astronomyService.getMeteorShowerPeakAzimuth(shower, location),
+            peakPosition.azimuth,
             declination
         )
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/MoonListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/MoonListItemProducer.kt
@@ -1,17 +1,16 @@
 package com.kylecorry.trail_sense.tools.astronomy.ui.items
 
 import android.content.Context
-import android.graphics.drawable.BitmapDrawable
-import com.kylecorry.luna.concurrency.onDefault
-import com.kylecorry.andromeda.views.list.ListItem
+import androidx.core.graphics.drawable.toDrawable
 import com.kylecorry.andromeda.views.list.DrawableListIcon
+import com.kylecorry.andromeda.views.list.ListItem
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.declination.DeclinationUtils
 import com.kylecorry.trail_sense.tools.astronomy.ui.MoonPhaseImageMapper
 import java.time.LocalDate
 import java.time.ZoneId
-import androidx.core.graphics.drawable.toDrawable
 
 class MoonListItemProducer(context: Context) : BaseAstroListItemProducer(context) {
 
@@ -39,15 +38,12 @@ class MoonListItemProducer(context: Context) : BaseAstroListItemProducer(context
 
         // Advanced
         val isSuperMoon = astronomyService.isSuperMoon(date)
-        val peak = times.transit?.let { astronomyService.getMoonAltitude(location, it) }
-        val azimuth =
-            if (date == LocalDate.now()) DeclinationUtils.fromTrueNorthBearing(
-                astronomyService.getMoonAzimuth(location),
-                declination
-            ) else null
-        val altitude =
-            if (date == LocalDate.now()) astronomyService.getMoonAltitude(location) else null
-
+        val peak = times.transit?.let { astronomyService.getMoonPosition(location, it).altitude }
+        val currentPosition = if (date == LocalDate.now()) astronomyService.getMoonPosition(location) else null
+        val azimuth = currentPosition?.let {
+            DeclinationUtils.fromTrueNorthBearing(it.azimuth, declination)
+        }
+        val altitude = currentPosition?.altitude
         list(
             2,
             context.getString(R.string.moon),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/SolarEclipseListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/SolarEclipseListItemProducer.kt
@@ -5,7 +5,6 @@ import androidx.core.graphics.drawable.toDrawable
 import com.kylecorry.andromeda.views.list.DrawableListIcon
 import com.kylecorry.andromeda.views.list.ListItem
 import com.kylecorry.luna.concurrency.onDefault
-import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.declination.DeclinationUtils
@@ -23,14 +22,12 @@ class SolarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
         val eclipse = astronomyService.getSolarEclipse(location, date) ?: return@onDefault null
 
         // Advanced
-        val sunAltitude = astronomyService.getSunAltitude(location, eclipse.peak)
-        val sunAzimuth = astronomyService.getSunAzimuth(location, eclipse.peak)
+        val sun = astronomyService.getSunPosition(location, eclipse.peak)
         val peakAzimuth = DeclinationUtils.fromTrueNorthBearing(
-            sunAzimuth,
+            sun.azimuth,
             declination
         )
-        val moonAltitude = astronomyService.getMoonAltitude(location, eclipse.peak)
-        val moonAzimuth = astronomyService.getMoonAzimuth(location, eclipse.peak)
+        val moon = astronomyService.getMoonPosition(location, eclipse.peak)
 
         list(
             5,
@@ -38,12 +35,8 @@ class SolarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
             EclipseFormatter.type(context, eclipse),
             DrawableListIcon(
                 SolarEclipseImageMapper(context).getEclipseImage(
-                    CelestialObservation(sunAzimuth, sunAltitude, astronomyService.getSunAngularDiameter(eclipse.peak)),
-                    CelestialObservation(
-                        moonAzimuth,
-                        moonAltitude,
-                        astronomyService.getMoonAngularDiameter(location, eclipse.peak)
-                    ),
+                    sun,
+                    moon,
                     eclipse.isTotal,
                     imageSize,
                     imageSize
@@ -66,7 +59,7 @@ class SolarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
                     )
                 ),
                 context.getString(R.string.magnitude) to decimal(eclipse.magnitude, 2),
-                context.getString(R.string.astronomy_altitude_peak) to degrees(sunAltitude),
+                context.getString(R.string.astronomy_altitude_peak) to degrees(sun.altitude),
                 context.getString(R.string.astronomy_direction_peak) to direction(peakAzimuth)
             )
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/SunListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/SunListItemProducer.kt
@@ -1,9 +1,9 @@
 package com.kylecorry.trail_sense.tools.astronomy.ui.items
 
 import android.content.Context
-import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.views.list.ListItem
 import com.kylecorry.andromeda.views.list.ResourceListIcon
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.sol.science.astronomy.SunTimesMode
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
@@ -28,17 +28,15 @@ class SunListItemProducer(context: Context) : BaseAstroListItemProducer(context)
         val nautical = astronomyService.getSunTimes(location, SunTimesMode.Nautical, date)
         val astronomical = astronomyService.getSunTimes(location, SunTimesMode.Astronomical, date)
         val peak = times.transit?.let {
-            astronomyService.getSunAltitude(location, it)
+            astronomyService.getSunPosition(location, it).altitude
         }
         val night = Duration.ofDays(1) - daylight
         val season = astronomyService.getSeason(location, date)
-        val azimuth = if (date == LocalDate.now()) DeclinationUtils.fromTrueNorthBearing(
-            astronomyService.getSunAzimuth(location),
-            declination
-        ) else null
-        val altitude =
-            if (date == LocalDate.now()) astronomyService.getSunAltitude(location) else null
-
+        val currentPosition = if (date == LocalDate.now()) astronomyService.getSunPosition(location) else null
+        val azimuth = currentPosition?.let {
+            DeclinationUtils.fromTrueNorthBearing(it.azimuth, declination)
+        }
+        val altitude = currentPosition?.altitude
         list(
             1,
             context.getString(R.string.sun),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/domain/calibration/ARCalibratorFactory.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/domain/calibration/ARCalibratorFactory.kt
@@ -11,11 +11,12 @@ class ARCalibratorFactory {
     private val astro = AstronomyService()
 
     suspend fun getSunCalibrator(location: Coordinate): IARCalibrator = onDefault {
+        val position = astro.getSunPosition(location)
         ARCenteredCalibrator(
             AugmentedRealityCoordinate(
                 AugmentedRealityUtils.toEastNorthUp(
-                    astro.getSunAzimuth(location).value,
-                    astro.getSunAltitude(location),
+                    position.azimuth.value,
+                    position.altitude,
                     Float.MAX_VALUE
                 ), true
             )
@@ -23,11 +24,12 @@ class ARCalibratorFactory {
     }
 
     suspend fun getMoonCalibrator(location: Coordinate): IARCalibrator = onDefault {
+        val position = astro.getMoonPosition(location)
         ARCenteredCalibrator(
             AugmentedRealityCoordinate(
                 AugmentedRealityUtils.toEastNorthUp(
-                    astro.getMoonAzimuth(location).value,
-                    astro.getMoonAltitude(location),
+                    position.azimuth.value,
+                    position.altitude,
                     Float.MAX_VALUE
                 ), true
             )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/domain/calibration/AutoSunCalibrator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/domain/calibration/AutoSunCalibrator.kt
@@ -36,7 +36,7 @@ class AutoSunCalibrator : IARCalibrator {
                 val actualBearing = (xPct - 0.5f) * camera.fov.first + view.azimuth
 
                 // Get the predicted location of the sun
-                val predictedBearing = astro.getSunAzimuth(view.location).value
+                val predictedBearing = astro.getSunPosition(view.location).azimuth.value
 
                 // Calculate the bearing difference
                 deltaAngle(actualBearing, predictedBearing)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/guidance/AstronomyGuidanceTarget.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/guidance/AstronomyGuidanceTarget.kt
@@ -1,7 +1,7 @@
 package com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance
 
-import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.sol.science.astronomy.Astronomy
 import com.kylecorry.sol.science.astronomy.locators.Planet
 import com.kylecorry.sol.science.astronomy.meteors.MeteorShower
@@ -35,14 +35,15 @@ class AstronomyGuidanceTarget(
 
         when (selection) {
             AstronomySelection.Sun -> {
+                val position = astronomyService.getSunPosition(location, time)
                 ARGuidanceTargetState(
                     ARGuidanceDisplayState(
                         view.context.getString(R.string.sun),
                         R.drawable.ic_sun
                     ),
                     SphericalARPoint(
-                        astronomyService.getSunAzimuth(location, time).value,
-                        astronomyService.getSunAltitude(location, time),
+                        position.azimuth.value,
+                        position.altitude,
                         isTrueNorth = true
                     )
                 )
@@ -50,6 +51,7 @@ class AstronomyGuidanceTarget(
 
             AstronomySelection.Moon -> {
                 val phase = astronomyService.getMoonPhase(time)
+                val position = astronomyService.getMoonPosition(location, time)
                 ARGuidanceTargetState(
                     ARGuidanceDisplayState(
                         view.context.getString(R.string.moon),
@@ -62,8 +64,8 @@ class AstronomyGuidanceTarget(
                         )
                     ),
                     SphericalARPoint(
-                        astronomyService.getMoonAzimuth(location, time).value,
-                        astronomyService.getMoonAltitude(location, time),
+                        position.azimuth.value,
+                        position.altitude,
                         isTrueNorth = true
                     )
                 )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/guidance/AstronomyGuidanceTargetPicker.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/guidance/AstronomyGuidanceTargetPicker.kt
@@ -1,16 +1,16 @@
 package com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance
 
+import android.graphics.drawable.BitmapDrawable
 import android.view.View
 import android.widget.TextView
-import android.graphics.drawable.BitmapDrawable
 import com.kylecorry.andromeda.alerts.Alerts
-import com.kylecorry.luna.concurrency.onDefault
+import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.andromeda.core.ui.Colors
 import com.kylecorry.andromeda.views.list.AndromedaListView
-import com.kylecorry.andromeda.views.list.ListItem
 import com.kylecorry.andromeda.views.list.DrawableListIcon
+import com.kylecorry.andromeda.views.list.ListItem
 import com.kylecorry.andromeda.views.list.ResourceListIcon
-import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.sol.science.astronomy.Astronomy
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.readableName
@@ -46,7 +46,7 @@ class AstronomyGuidanceTargetPicker(
 
             val options = mutableListOf<AstronomyGuidanceOption>()
 
-            val sunAltitude = astronomyService.getSunAltitude(location, time)
+            val sunAltitude = astronomyService.getSunPosition(location, time).altitude
             if (drawBelowHorizon || sunAltitude > 0f) {
                 options.add(
                     AstronomyGuidanceOption(
@@ -59,7 +59,7 @@ class AstronomyGuidanceTargetPicker(
                 )
             }
 
-            val moonAltitude = astronomyService.getMoonAltitude(location, time)
+            val moonAltitude = astronomyService.getMoonPosition(location, time).altitude
             if (drawBelowHorizon || moonAltitude > 0f) {
                 val phase = astronomyService.getMoonPhase(time)
                 options.add(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/layers/ARAstronomyLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/augmented_reality/ui/layers/ARAstronomyLayer.kt
@@ -32,8 +32,8 @@ import com.kylecorry.trail_sense.tools.augmented_reality.ui.AugmentedRealityView
 import com.kylecorry.trail_sense.tools.augmented_reality.ui.CanvasBitmap
 import com.kylecorry.trail_sense.tools.augmented_reality.ui.CanvasCircle
 import com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance.ARGuidanceLayer
-import com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance.AstronomyGuidanceTargetPicker
 import com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance.ARGuidanceTarget
+import com.kylecorry.trail_sense.tools.augmented_reality.ui.guidance.AstronomyGuidanceTargetPicker
 import com.kylecorry.trail_sense.tools.navigation.ui.DrawerBitmapLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -216,11 +216,12 @@ class ARAstronomyLayer(
                         }
 
                         val phase = astro.getMoonPhase(it)
+                        val position = astro.getMoonPosition(location, it)
 
                         ARMarker(
                             SphericalARPoint(
-                                astro.getMoonAzimuth(location, it).value,
-                                astro.getMoonAltitude(location, it),
+                                position.azimuth.value,
+                                position.altitude,
                                 isTrueNorth = true,
                                 angularDiameter = 0.5f
                             ),
@@ -246,11 +247,11 @@ class ARAstronomyLayer(
                         } else {
                             sunAfterPathObject
                         }
-
+                        val position = astro.getSunPosition(location, it)
                         ARMarker(
                             SphericalARPoint(
-                                astro.getSunAzimuth(location, it).value,
-                                astro.getSunAltitude(location, it),
+                                position.azimuth.value,
+                                position.altitude,
                                 isTrueNorth = true,
                                 angularDiameter = 0.5f
                             ),
@@ -263,11 +264,14 @@ class ARAstronomyLayer(
                 } else {
                     emptyList()
                 }
-                val moonAltitude = astro.getMoonAltitude(location, time)
-                val moonAzimuth = astro.getMoonAzimuth(location, time).value
+                val moonPosition = astro.getMoonPosition(location, time)
+                val sunPosition = astro.getSunPosition(location, time)
 
-                val sunAltitude = astro.getSunAltitude(location, time)
-                val sunAzimuth = astro.getSunAzimuth(location, time).value
+                val moonAltitude = moonPosition.altitude
+                val moonAzimuth = moonPosition.azimuth.value
+
+                val sunAltitude = sunPosition.altitude
+                val sunAzimuth = sunPosition.azimuth.value
 
                 val phase = astro.getMoonPhase(time)
                 val moonImageSize = drawer.dp(24f).toInt()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/data/NavAstronomyDataCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/data/NavAstronomyDataCommand.kt
@@ -1,7 +1,7 @@
 package com.kylecorry.trail_sense.tools.navigation.ui.data
 
-import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.sense.location.IGPS
+import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.trail_sense.shared.commands.CoroutineValueCommand
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
 import java.time.LocalDate
@@ -10,9 +10,11 @@ class NavAstronomyDataCommand(private val gps: IGPS) : CoroutineValueCommand<Nav
     val astronomy = AstronomyService()
 
     override suspend fun execute(): NavAstronomyData = onDefault {
+        val moonPosition = astronomy.getMoonPosition(gps.location)
+        val sunPosition = astronomy.getSunPosition(gps.location)
         NavAstronomyData(
-            astronomy.getSunAzimuth(gps.location).value,
-            astronomy.getMoonAzimuth(gps.location).value,
+            sunPosition.azimuth.value,
+            moonPosition.azimuth.value,
             astronomy.isSunUp(gps.location),
             astronomy.isMoonUp(gps.location),
             astronomy.getMoonPhase(LocalDate.now()).phaseAngle,

--- a/app/src/main/res/drawable/ic_moon_partial_eclipse.xml
+++ b/app/src/main/res/drawable/ic_moon_partial_eclipse.xml
@@ -1,8 +1,0 @@
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_moon"/>
-    <item>
-        <vector android:width="24dp" android:height="24dp" android:viewportWidth="551.1" android:viewportHeight="551.1">
-            <path android:fillAlpha="0.4" android:fillColor="@color/orange" android:pathData="M246.48 2.93C167.72 10.88 92.35 50.27 48.35 120.11-57.98 263.58 21.76 492.23 194.2 538.54c16.49 5.78 33.25 9.62 50.04 11.67 132.97-15.86 252.13-134.45 246.81-274.66 0.15-61.61-21.22-122.95-59.65-171.12-44.51-60.65-113.2-94.24-184.92-101.5zm34.03 549c-187.01-0.55-93.5-0.27 0 0zm-0.07 0c-186.96-0.55-93.48-0.28 0 0z"/>
-        </vector>
-    </item>
-</layer-list>

--- a/app/src/main/res/drawable/ic_moon_total_eclipse.xml
+++ b/app/src/main/res/drawable/ic_moon_total_eclipse.xml
@@ -1,8 +1,0 @@
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_moon"/>
-    <item>
-        <vector android:width="24dp" android:height="24dp" android:viewportWidth="551.1" android:viewportHeight="551.1">
-            <path android:fillAlpha="0.4" android:fillColor="@color/orange" android:pathData="M550.84 275.55c6.78 178.52-188.26 322.01-356.64 262.99C21.76 492.23-57.98 263.58 48.35 120.11 143.56-31 385.54-39.57 491.19 104.43c38.43 48.18 59.8 109.51 59.65 171.12z"/>
-        </vector>
-    </item>
-</layer-list>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,7 +3,6 @@
     <color name="orange_10">#351000</color>
     <color name="orange_40">#FF6D00</color>
     <color name="tool_icon_color">#FF6D00</color>
-    <color name="orange_40_transparent">#80FF6D00</color>
     <color name="colorPrimaryLight">#FD750E</color>
     <color name="colorSecondary">#222222</color>
     <color name="white">#FFFFFF</color>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ mockitoKotlin = "6.3.0"
 mapsforge = "2d514f37cd"
 orion = "1.1.0"
 roomVersion = "2.8.4"
-sol = "18.1.0"
+sol = "19.0.1"
 workRuntimeKtx = "2.11.2"
 preferenceKtx = "1.2.1"
 


### PR DESCRIPTION
Update sol to consume lunar eclipse shadow position, which also switches away from azimuth and altitude getters to a position getter. Adjust AstronomyService to passthrough the position. Render the lunar eclipses in the same way solar eclipses were rendered.

Issue: #3856 


## Checklist
<!-- Some of these may only apply to code, if you are performing a content update, I don't care how you fill out the code related checklist items -->

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
