### PR TITLE
Refactor offline maps to use OfflineMapFile

### DIFF
--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/offline_maps/ToolOfflineMapsTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/offline_maps/ToolOfflineMapsTest.kt
@@ -22,6 +22,8 @@ import com.kylecorry.trail_sense.test_utils.TestUtils.waitFor
 import com.kylecorry.trail_sense.test_utils.ToolTestBase
 import com.kylecorry.trail_sense.test_utils.views.Side
 import com.kylecorry.trail_sense.test_utils.views.toolbarButton
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
+import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMapFileType
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.MapService
@@ -206,8 +208,7 @@ class ToolOfflineMapsTest : ToolTestBase(Tools.OFFLINE_MAPS) {
                 0,
                 name,
                 VectorMapFileType.Mapsforge,
-                path,
-                0,
+                listOf(OfflineMapFile(path, 0, VectorMap.FILE_ROLE_MAPSFORGE_MAP)),
                 Instant.now(),
                 null,
                 null,

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/io/FileSubsystem.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/io/FileSubsystem.kt
@@ -36,8 +36,6 @@ class FileSubsystem private constructor(private val context: Context) {
     private val local = LocalFileSystem(context)
     private val assetFiles = AssetFileSystem(context)
 
-    val SCHEME_ASSETS = "android-assets://"
-
     fun bitmap(path: String, maxWidth: Int, maxHeight: Int): Bitmap? {
         return bitmap(path, Size(maxWidth, maxHeight))
     }
@@ -275,7 +273,7 @@ class FileSubsystem private constructor(private val context: Context) {
 
     companion object {
         const val SCHEME_CONTENT = "content://"
-
+        const val SCHEME_ASSETS = "android-assets://"
         private const val TEMP_DIR = "tmp"
 
         @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/clouds/infrastructure/CloudDetailsService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/clouds/infrastructure/CloudDetailsService.kt
@@ -77,16 +77,16 @@ class CloudDetailsService(private val context: Context) {
     fun getCloudImage(context: Context, type: CloudGenus?): Drawable? {
         val files = DependencyRegistry.get<FileSubsystem>()
         return when (type) {
-            CloudGenus.Cirrus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/cirrus.webp")
-            CloudGenus.Cirrocumulus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/cirrocumulus.webp")
-            CloudGenus.Cirrostratus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/cirrostratus.webp")
-            CloudGenus.Altocumulus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/altocumulus.webp")
-            CloudGenus.Altostratus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/altostratus.webp")
-            CloudGenus.Nimbostratus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/nimbostratus.webp")
-            CloudGenus.Stratus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/stratus.webp")
-            CloudGenus.Stratocumulus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/stratocumulus.webp")
-            CloudGenus.Cumulus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/cumulus.webp")
-            CloudGenus.Cumulonimbus -> files.drawable("${files.SCHEME_ASSETS}survival_guide/cumulonimbus.webp")
+            CloudGenus.Cirrus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/cirrus.webp")
+            CloudGenus.Cirrocumulus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/cirrocumulus.webp")
+            CloudGenus.Cirrostratus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/cirrostratus.webp")
+            CloudGenus.Altocumulus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/altocumulus.webp")
+            CloudGenus.Altostratus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/altostratus.webp")
+            CloudGenus.Nimbostratus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/nimbostratus.webp")
+            CloudGenus.Stratus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/stratus.webp")
+            CloudGenus.Stratocumulus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/stratocumulus.webp")
+            CloudGenus.Cumulus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/cumulus.webp")
+            CloudGenus.Cumulonimbus -> files.drawable("${FileSubsystem.SCHEME_ASSETS}survival_guide/cumulonimbus.webp")
             null -> Resources.drawable(context, R.drawable.rectangle)
                 ?.also { it.setTint("#84bfdf".toColorInt()) }
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
@@ -10,6 +10,7 @@ import com.kylecorry.andromeda.bitmaps.operations.ReplaceColor
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.shared.map_layers.tiles.Tile
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
@@ -32,7 +33,7 @@ class BaseMapTileSource : TileSource {
                 -1,
                 "Land",
                 listOf(
-                    OfflineMapFile("land.webp", 0, PhotoMap.FILE_ROLE_IMAGE)
+                    OfflineMapFile("${FileSubsystem.SCHEME_ASSETS}land.webp", 0, PhotoMap.FILE_ROLE_IMAGE)
                 ),
                 PhotoMapGeoreference(
                     Size(3800f, 1900f),
@@ -49,8 +50,7 @@ class BaseMapTileSource : TileSource {
                         )
                     ),
                     isFullWorld = true // TODO: Derive this using calibration points
-                ),
-                isAsset = true,
+                )
             )
         ),
         decoderCache,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/map/map_layers/BaseMapTileSource.kt
@@ -12,6 +12,7 @@ import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.shared.map_layers.tiles.Tile
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapCalibrationPoint
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapProjectionType
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PercentCoordinate
@@ -30,8 +31,9 @@ class BaseMapTileSource : TileSource {
             PhotoMap(
                 -1,
                 "Land",
-                "land.webp",
-                0,
+                listOf(
+                    OfflineMapFile("land.webp", 0, PhotoMap.FILE_ROLE_IMAGE)
+                ),
                 PhotoMapGeoreference(
                     Size(3800f, 1900f),
                     projectionType = MapProjectionType.CylindricalEquidistant,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapFile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapFile.kt
@@ -1,0 +1,11 @@
+package com.kylecorry.trail_sense.tools.offline_maps.domain
+
+import com.kylecorry.trail_sense.shared.io.FileSubsystem
+
+data class OfflineMapFile(
+    val path: String,
+    val sizeBytes: Long,
+    val role: String
+) {
+    val isExternal = path.startsWith(FileSubsystem.SCHEME_CONTENT)
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapFile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapFile.kt
@@ -8,4 +8,5 @@ data class OfflineMapFile(
     val role: String
 ) {
     val isExternal = path.startsWith(FileSubsystem.SCHEME_CONTENT)
+    val isAsset = path.startsWith(FileSubsystem.SCHEME_ASSETS)
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
@@ -19,7 +19,6 @@ data class PhotoMap(
     val georeference: PhotoMapGeoreference,
     override val parentId: Long? = null,
     val visible: Boolean = true,
-    val isAsset: Boolean = false,
     val createdOn: Instant? = null,
 ) : IMap {
     override val isGroup = false

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
@@ -1,15 +1,13 @@
 package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps
 
-import android.content.Context
-import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.luna.hooks.Hooks
 import com.kylecorry.sol.math.MathExtensions.roundNearestAngle
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.science.geography.projections.IMapProjection
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.sol.units.Distance
-import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.projections.PhotoMapProjection
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.projections.distancePerPixel
 import java.time.Instant
@@ -17,8 +15,7 @@ import java.time.Instant
 data class PhotoMap(
     override val id: Long,
     override val name: String,
-    val filename: String,
-    val fileSizeBytes: Long,
+    val files: List<OfflineMapFile>,
     val georeference: PhotoMapGeoreference,
     override val parentId: Long? = null,
     val visible: Boolean = true,
@@ -28,7 +25,9 @@ data class PhotoMap(
     override val isGroup = false
     override val count: Int? = null
 
-    val pdfFileName = filename.replace(".webp", "") + ".pdf"
+    val imageFile = files.single { it.role == FILE_ROLE_IMAGE }
+    val pdfFile = files.singleOrNull { it.role == FILE_ROLE_PDF }
+    val fileSizeBytes = files.sumOf { it.sizeBytes }
 
     private val hooks = Hooks()
 
@@ -109,13 +108,11 @@ data class PhotoMap(
         }
     }
 
-    fun hasPdf(context: Context): Boolean {
-        return DependencyRegistry.get<FileSubsystem>().get(pdfFileName).exists()
-    }
-
     companion object {
         // TODO: Make this based on meters per pixel
         const val DESIRED_PDF_SIZE = 20000
+        const val FILE_ROLE_PDF = "pdf"
+        const val FILE_ROLE_IMAGE = "image"
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapEntity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapEntity.kt
@@ -6,6 +6,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import java.time.Instant
 
 @Entity(tableName = "maps", indices = [Index(value = ["parent"])])
@@ -71,8 +72,9 @@ data class PhotoMapEntity(
         return PhotoMap(
             id,
             name,
-            filename,
-            0,
+            listOf(
+                OfflineMapFile(filename, 0, PhotoMap.FILE_ROLE_IMAGE)
+            ),
             metadata,
             parent,
             visible,
@@ -84,7 +86,7 @@ data class PhotoMapEntity(
             val metadata = map.georeference
             return PhotoMapEntity(
                 map.name,
-                map.filename,
+                map.imageFile.path,
                 if (metadata.calibrationPoints.isNotEmpty()) metadata.calibrationPoints[0].location.latitude else null,
                 if (metadata.calibrationPoints.isNotEmpty()) metadata.calibrationPoints[0].location.longitude else null,
                 if (metadata.calibrationPoints.isNotEmpty()) metadata.calibrationPoints[0].imageLocation.x else null,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/vector_maps/VectorMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/vector_maps/VectorMap.kt
@@ -1,16 +1,15 @@
 package com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps
 
 import com.kylecorry.sol.science.geology.CoordinateBounds
-import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import java.time.Instant
 
 data class VectorMap(
     override val id: Long,
     override val name: String,
     val type: VectorMapFileType,
-    val path: String,
-    val sizeBytes: Long,
+    val files: List<OfflineMapFile>,
     val createdOn: Instant,
     val bounds: CoordinateBounds?,
     val attribution: String?,
@@ -20,5 +19,10 @@ data class VectorMap(
 ) : IMap {
     override val isGroup = false
     override val count: Int? = null
-    val isExternal: Boolean = path.startsWith(FileSubsystem.SCHEME_CONTENT)
+    val mapFile = files.single { it.role == FILE_ROLE_MAPSFORGE_MAP }
+    val isExternal = files.any { it.isExternal }
+
+    companion object {
+        const val FILE_ROLE_MAPSFORGE_MAP = "mapsforge-map"
+    }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/vector_maps/VectorMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/vector_maps/VectorMap.kt
@@ -21,6 +21,7 @@ data class VectorMap(
     override val count: Int? = null
     val mapFile = files.single { it.role == FILE_ROLE_MAPSFORGE_MAP }
     val isExternal = files.any { it.isExternal }
+    val fileSizeBytes = files.sumOf { it.sizeBytes }
 
     companion object {
         const val FILE_ROLE_MAPSFORGE_MAP = "mapsforge-map"

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateMapFromImageCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateMapFromImageCommand.kt
@@ -8,6 +8,7 @@ import com.kylecorry.andromeda.core.tryOrLog
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapGeoreference
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.MapService
@@ -35,8 +36,9 @@ class CreateMapFromImageCommand(
         val map = PhotoMap(
             0,
             name,
-            path,
-            fileSize,
+            listOf(
+                OfflineMapFile(path, fileSize, PhotoMap.FILE_ROLE_IMAGE)
+            ),
             PhotoMapGeoreference(
                 Size(imageSize.width.toFloat(), imageSize.height.toFloat()),
                 rotation = rotation.toFloat()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateMapFromPDFCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateMapFromPDFCommand.kt
@@ -12,6 +12,7 @@ import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapCalibrationPoint
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapGeoreference
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapProjectionType
@@ -34,6 +35,7 @@ class CreateMapFromPDFCommand(
     suspend fun execute(uri: Uri): PhotoMap? = onIO {
         val uuid = UUID.randomUUID().toString()
         val filename = "maps/$uuid.webp"
+        val pdfFilename = "maps/$uuid.pdf"
         val calibrationPoints = mutableListOf<MapCalibrationPoint>()
         var projection = MapProjectionType.CylindricalEquidistant
 
@@ -92,8 +94,10 @@ class CreateMapFromPDFCommand(
         val map = PhotoMap(
             0,
             name,
-            filename,
-            fileSize,
+            listOf(
+                OfflineMapFile(filename, fileSize, PhotoMap.FILE_ROLE_IMAGE),
+                OfflineMapFile(pdfFilename, files.size(pdfFilename), PhotoMap.FILE_ROLE_PDF)
+            ),
             PhotoMapGeoreference(
                 Size(imageSize.width.toFloat(), imageSize.height.toFloat()),
                 pdfSize?.let { Size(it.width.toFloat(), it.height.toFloat()) },

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateVectorMapFromFileCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/create/CreateVectorMapFromFileCommand.kt
@@ -7,6 +7,7 @@ import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMapFileType
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.MapService
@@ -45,8 +46,9 @@ class CreateVectorMapFromFileCommand(
             0,
             name,
             type,
-            path,
-            files.size(path),
+            listOf(
+                OfflineMapFile(path, files.size(path), VectorMap.FILE_ROLE_MAPSFORGE_MAP)
+            ),
             Instant.now(),
             info.bounds,
             info.attribution,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
@@ -13,6 +13,7 @@ import com.kylecorry.trail_sense.main.persistence.AppDatabase
 import com.kylecorry.trail_sense.shared.getUpsertedId
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.tools.offline_maps.OfflineMapsToolRegistration
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapType
 import com.kylecorry.trail_sense.tools.offline_maps.domain.groups.MapGroup
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
@@ -63,7 +64,9 @@ class MapRepo private constructor(context: Context) {
         if (map.isExternal) {
             releaseExternalAccessIfUnused(map)
         } else {
-            tryOrNothing { files.delete(map.path) }
+            map.files.forEach {
+                tryOrNothing { files.delete(it.path) }
+            }
         }
         offlineMapFileDao.delete(VectorMapEntity.from(map))
         emit(OfflineMapsToolRegistration.BROADCAST_OFFLINE_MAP_DELETED, map.id, OfflineMapType.Trail)
@@ -74,24 +77,30 @@ class MapRepo private constructor(context: Context) {
             return@onIO map
         }
 
+        // This currently only supports a single map file, once additional files are added this will need to be modified
         val extension = MapFileTypeUtils.getExtension(map.type)
         val saved = files.copyToLocal(
-            map.path.toUri(),
+            map.mapFile.path.toUri(),
             OFFLINE_MAPS_DIRECTORY,
             "${UUID.randomUUID()}.$extension"
         ) ?: return@onIO null
 
-        val updated = map.copy(path = files.getLocalPath(saved), sizeBytes = saved.length())
+        val updated = map.copy(
+            files = listOf(
+                OfflineMapFile(files.getLocalPath(saved), saved.length(), VectorMap.FILE_ROLE_MAPSFORGE_MAP)
+            )
+        )
         add(updated)
         releaseExternalAccessIfUnused(map)
         updated
     }
 
     private suspend fun releaseExternalAccessIfUnused(map: VectorMap) = onIO {
-        val isUsedByOtherMaps = offlineMapFileDao.getAllSync()
-            .any { it.id != map.id && it.path == map.path }
-        if (!isUsedByOtherMaps) {
-            tryOrNothing { files.releasePersistentAccess(map.path.toUri()) }
+        val otherMaps = offlineMapFileDao.getAllSync().filter { it.id != map.id }
+        for (file in map.files) {
+            if (otherMaps.none { it.path == file.path }) {
+                files.releasePersistentAccess(file.path.toUri())
+            }
         }
     }
 
@@ -145,7 +154,7 @@ class MapRepo private constructor(context: Context) {
     private fun convertToMap(map: VectorMapEntity): VectorMap {
         val newMap = map.toOfflineMapFile()
         return if (newMap.isExternal) {
-            newMap.copy(isAvailable = files.canRead(newMap.path))
+            newMap.copy(isAvailable = newMap.files.all { files.canRead(it.path) })
         } else {
             newMap
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
@@ -54,8 +54,9 @@ class MapRepo private constructor(context: Context) {
     }
 
     suspend fun delete(map: PhotoMap) = onIO {
-        tryOrNothing { files.delete(map.filename) }
-        tryOrNothing { files.delete(map.pdfFileName) }
+        map.files.forEach {
+            tryOrNothing { files.delete(it.path) }
+        }
         photoMapDao.delete(PhotoMapEntity.from(map))
         emit(OfflineMapsToolRegistration.BROADCAST_OFFLINE_MAP_DELETED, map.id, OfflineMapType.Photo)
     }
@@ -163,14 +164,12 @@ class MapRepo private constructor(context: Context) {
     private fun convertToMap(map: PhotoMapEntity): PhotoMap {
         val newMap = map.toMap()
         // TODO: Save the size in the DB
-        val size = files.imageSize(newMap.filename)
-        val fileSize = files.size(newMap.filename) + files.size(newMap.pdfFileName)
+        val size = files.imageSize(newMap.imageFile.path)
+        val pdfFilename = map.filename.replace(".webp", "") + ".pdf"
+        val hasPdf = map.pdfHeight != null && map.pdfWidth != null && files.get(pdfFilename).exists()
 
         val pdfSize =
-            if (map.pdfHeight != null && map.pdfWidth != null && files.get(newMap.pdfFileName)
-                    .exists()
-            ) {
-
+            if (hasPdf) {
                 val scaledSize = MathUtils.scaleToBounds(
                     Size(map.pdfWidth, map.pdfHeight),
                     Size(PhotoMap.DESIRED_PDF_SIZE, PhotoMap.DESIRED_PDF_SIZE)
@@ -185,7 +184,10 @@ class MapRepo private constructor(context: Context) {
             }
 
         return newMap.copy(
-            fileSizeBytes = fileSize,
+            files = listOfNotNull(
+                OfflineMapFile(map.filename, files.size(map.filename), PhotoMap.FILE_ROLE_IMAGE),
+                if (hasPdf) OfflineMapFile(pdfFilename, files.size(pdfFilename), PhotoMap.FILE_ROLE_PDF) else null
+            ),
             georeference = newMap.georeference.copy(
                 size = pdfSize ?: com.kylecorry.sol.math.geometry.Size(
                     size.width.toFloat(),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/MapExportService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/MapExportService.kt
@@ -37,11 +37,11 @@ class MapExportService(
 
     override suspend fun export(data: PhotoMap, filename: String): Boolean {
         // If the map was auto calibrated and the PDF exists, just copy it
-        if (data.hasPdf(context) && isGeospatialPdf(data.pdfFileName)) {
+        if (data.pdfFile != null && isGeospatialPdf(data.pdfFile.path)) {
             val uri = uriPicker.create(filename, "application/pdf") ?: return false
             val outputStream = files.output(uri) ?: return false
             val saver = FileSaver()
-            saver.save(files.get(data.pdfFileName), outputStream)
+            saver.save(files.get(data.pdfFile.path), outputStream)
             return true
         }
 
@@ -70,7 +70,7 @@ class MapExportService(
             val maxImageSize = 2048
 
             bitmap =
-                files.bitmap(map.filename, Size(maxImageSize, maxImageSize)) ?: return emptyList()
+                files.bitmap(map.imageFile.path, Size(maxImageSize, maxImageSize)) ?: return emptyList()
 
             if (map.georeference.rotation != 0f) {
                 val rotated = bitmap.rotate(map.georeference.rotation)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
@@ -28,14 +28,14 @@ class MapCleanupCommand(context: Context) : CoroutineValueCommand<Boolean> {
         val allFiles = files.list(OFFLINE_MAPS_DIRECTORY).map { "$OFFLINE_MAPS_DIRECTORY/${it.name}" }
 
         // Delete files without a map
-        val mapFiles = maps.map { it.path }
+        val mapFiles = maps.flatMap { it.files.map { file -> file.path } }
         val orphanedFiles = allFiles.filter { !mapFiles.contains(it) }
         orphanedFiles.forEach {
             files.delete(it)
         }
 
         // Delete maps without a file
-        val toDelete = maps.filter { !allFiles.contains(it.path) }
+        val toDelete = maps.filter { !allFiles.contains(it.mapFile.path) }
         toDelete.forEach {
             service.delete(it)
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
@@ -48,14 +48,14 @@ class MapCleanupCommand(context: Context) : CoroutineValueCommand<Boolean> {
         val allFiles = files.list("maps").map { "maps/${it.name}" }
 
         // Delete files without a map
-        val mapFiles = maps.flatMap { listOf(it.filename, it.pdfFileName) }
+        val mapFiles = maps.flatMap { it.files.map { file -> file.path } }
         val orphanedFiles = allFiles.filter { !mapFiles.contains(it) }
         orphanedFiles.forEach {
             files.delete(it)
         }
 
         // Delete maps without a file
-        val toDelete = maps.filter { !allFiles.contains(it.filename) }
+        val toDelete = maps.filter { !allFiles.contains(it.imageFile.path) }
 
         toDelete.forEach {
             service.delete(it)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/PrintMapCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/PrintMapCommand.kt
@@ -15,10 +15,10 @@ class PrintMapCommand(private val context: Context) {
         val printer = Printer(context)
         val files = FileSubsystem.getInstance(context)
 
-        val uri = if (map.hasPdf(context)) {
-            files.uri(map.pdfFileName)
+        val uri = if (map.pdfFile != null) {
+            files.uri(map.pdfFile.path)
         } else {
-            files.uri(map.filename)
+            files.uri(map.imageFile.path)
         }
 
         printer.setColorMode(ColorMode.Color)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/reduce/BaseMapReduce.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/reduce/BaseMapReduce.kt
@@ -6,6 +6,7 @@ import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.extensions.toAndroidSize
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.MapService
 import java.util.UUID
@@ -20,19 +21,27 @@ abstract class BaseMapReduce(
     private val files = FileSubsystem.getInstance(context)
 
     override suspend fun reduce(map: PhotoMap) = onIO {
-        val bmp = files.bitmap(map.filename, maxSize?.toAndroidSize()) ?: return@onIO
-        files.save(map.filename, bmp, quality, true)
+        val originalFileName = map.imageFile.path
+        val bmp = files.bitmap(originalFileName, maxSize?.toAndroidSize()) ?: return@onIO
+        files.save(originalFileName, bmp, quality, true)
 
         // Remove the PDF
-        files.delete(map.pdfFileName)
+        map.pdfFile?.let { files.delete(it.path) }
 
-        var updatedMap = map
-        if (!map.filename.endsWith(".webp")) {
-            val newFileName = "maps/" + UUID.randomUUID().toString() + ".webp"
-            if (files.rename(map.filename, newFileName)) {
-                updatedMap = map.copy(filename = newFileName)
+        val newFileName = if (!originalFileName.endsWith(".webp")) {
+            val newName = "maps/" + UUID.randomUUID().toString() + ".webp"
+            if (files.rename(originalFileName, newName)) {
+                newName
+            } else {
+                originalFileName
             }
+        } else {
+            originalFileName
         }
+        val newFiles = listOf(
+            OfflineMapFile(newFileName, files.size(newFileName), PhotoMap.FILE_ROLE_IMAGE)
+        )
+        val updatedMap = map.copy(files = newFiles)
         service.add(updatedMap)
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapDecoderCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapDecoderCache.kt
@@ -49,8 +49,8 @@ class PhotoMapDecoderCache {
             loaders[map]?.let { return it }
             val decoder = ImageRegionDecoder(context, Bitmap.Config.ARGB_8888)
 
-            if (map.isAsset) {
-                decoder.initFromAsset(map.imageFile.path.removePrefix(files.SCHEME_ASSETS))
+            if (map.imageFile.isAsset) {
+                decoder.initFromAsset(map.imageFile.path.removePrefix(FileSubsystem.SCHEME_ASSETS))
             } else {
                 decoder.init(files.uri(map.imageFile.path))
             }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapDecoderCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapDecoderCache.kt
@@ -32,7 +32,8 @@ class PhotoMapDecoderCache {
         return getLock(map).withLock {
             loaders[map]?.let { return it }
             val decoder = PdfImageRegionDecoder(Bitmap.Config.ARGB_8888)
-            decoder.init(context, files.uri(map.pdfFileName))
+            // This only operates on PDF maps, so pdfFile is guaranteed not null
+            decoder.init(context, files.uri(checkNotNull(map.pdfFile).path))
             loaders[map] = decoder
             decoder
         }
@@ -49,9 +50,9 @@ class PhotoMapDecoderCache {
             val decoder = ImageRegionDecoder(context, Bitmap.Config.ARGB_8888)
 
             if (map.isAsset) {
-                decoder.initFromAsset(map.filename.removePrefix(files.SCHEME_ASSETS))
+                decoder.initFromAsset(map.imageFile.path.removePrefix(files.SCHEME_ASSETS))
             } else {
-                decoder.init(files.uri(map.filename))
+                decoder.init(files.uri(map.imageFile.path))
             }
 
             loaders[map] = decoder

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapRegionLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapRegionLoader.kt
@@ -88,7 +88,7 @@ class PhotoMapRegionLoader(
             (maxSize.height * sampleSizeMultiplier).roundToInt()
         )
 
-        val isPdf = loadPdfs && map.hasPdf(context)
+        val isPdf = loadPdfs && map.pdfFile != null
         val bitmap = decoderCache.decodeRegion(context, map, region, inSampleSize, isPdf)
 
         bitmap?.applyOperationsOrNull(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/vector_maps/mapsforge/MapsforgeTileRenderer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/vector_maps/mapsforge/MapsforgeTileRenderer.kt
@@ -89,7 +89,7 @@ class MapsforgeTileRenderer(
     ): MapsforgeRendererHolder? {
         val mapFiles = maps
             .filter { it.type == VectorMapFileType.Mapsforge }
-            .mapNotNull { MapsforgeAdapter.open(it.path) }
+            .mapNotNull { MapsforgeAdapter.open(it.mapFile.path) }
         if (mapFiles.isEmpty()) {
             return null
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/vector_maps/persistence/VectorMapEntity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/vector_maps/persistence/VectorMapEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.kylecorry.sol.science.geology.CoordinateBounds
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.vector_maps.VectorMapFileType
 import java.time.Instant
@@ -36,8 +37,9 @@ data class VectorMapEntity(
             name,
             VectorMapFileType.entries.firstOrNull { it.id == type }
                 ?: VectorMapFileType.Mapsforge,
-            path,
-            sizeBytes,
+            listOf(
+                OfflineMapFile(path, sizeBytes, VectorMap.FILE_ROLE_MAPSFORGE_MAP)
+            ),
             Instant.ofEpochMilli(createdOn),
             if (hasLatitudeBounds && hasLongitudeBounds) {
                 CoordinateBounds(north, east, south, west)
@@ -55,8 +57,8 @@ data class VectorMapEntity(
             return VectorMapEntity(
                 file.name,
                 file.type.id,
-                file.path,
-                file.sizeBytes,
+                file.mapFile.path,
+                file.mapFile.sizeBytes,
                 file.createdOn.toEpochMilli(),
                 file.bounds?.north,
                 file.bounds?.east,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/OfflineMapListFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/OfflineMapListFragment.kt
@@ -449,7 +449,7 @@ class OfflineMapListFragment : BoundFragment<FragmentOfflineMapListBinding>() {
                 }
 
                 if (map is PhotoMap) {
-                    val isPdfMap = map.hasPdf(requireContext())
+                    val isPdfMap = map.pdfFile != null
                     if ((isPdfMap && prefs.photoMaps.autoReducePdfMaps) || (!isPdfMap && prefs.photoMaps.autoReducePhotoMaps)) {
                         mapImportingIndicator.show()
                         val reducer = HighQualityMapReducer(requireContext())

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/PhotoMapListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/PhotoMapListItemMapper.kt
@@ -117,7 +117,7 @@ class PhotoMapListItemMapper(
     private suspend fun loadMapThumbnail(map: PhotoMap): Bitmap = onIO {
         val size = Resources.dp(context, 48f).toInt()
         val bitmap = try {
-            files.bitmap(map.filename, Size(size, size)) ?: getDefaultMapThumbnail()
+            files.bitmap(map.imageFile.path, Size(size, size)) ?: getDefaultMapThumbnail()
         } catch (e: Exception) {
             getDefaultMapThumbnail()
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/VectorMapListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/VectorMapListItemMapper.kt
@@ -31,7 +31,7 @@ class VectorMapListItemMapper(
             icon = ResourceListIcon(R.drawable.maps, AppColor.Gray.color, size = 48f, foregroundSize = 24f),
             subtitle = formatter.join(
                 formatter.formatDate(value.createdOn.toZonedDateTime(), includeWeekDay = false),
-                formatter.formatFileSize(value.files.sumOf { it.sizeBytes }),
+                formatter.formatFileSize(value.fileSizeBytes),
                 separator = FormatService.Separator.Dot
             ),
             tags = getTags(value),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/VectorMapListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/VectorMapListItemMapper.kt
@@ -31,7 +31,7 @@ class VectorMapListItemMapper(
             icon = ResourceListIcon(R.drawable.maps, AppColor.Gray.color, size = 48f, foregroundSize = 24f),
             subtitle = formatter.join(
                 formatter.formatDate(value.createdOn.toZonedDateTime(), includeWeekDay = false),
-                formatter.formatFileSize(value.sizeBytes),
+                formatter.formatFileSize(value.files.sumOf { it.sizeBytes }),
                 separator = FormatService.Separator.Dot
             ),
             tags = getTags(value),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/BasePhotoMapView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/BasePhotoMapView.kt
@@ -279,10 +279,10 @@ abstract class BasePhotoMapView : EnhancedImageView, IMapView {
             mapAzimuth = 0f
         }
 
-        if (files.get(map.pdfFileName).exists()) {
-            setImage(map.pdfFileName, rotation)
+        if (map.pdfFile != null) {
+            setImage(map.pdfFile.path, rotation)
         } else {
-            setImage(map.filename, rotation)
+            setImage(map.imageFile.path, rotation)
         }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/WarpMapFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/WarpMapFragment.kt
@@ -123,7 +123,7 @@ class WarpMapFragment : BoundFragment<FragmentPhotoMapsPerspectiveBinding>() {
     private fun onMapLoad(map: PhotoMap) {
         this.map = map
         binding.perspective.mapRotation = map.georeference.rotation
-        binding.perspective.setImage(map.filename)
+        binding.perspective.setImage(map.imageFile.path)
         binding.nextButton.isInvisible = false
     }
 
@@ -139,18 +139,18 @@ class WarpMapFragment : BoundFragment<FragmentPhotoMapsPerspectiveBinding>() {
         }
         onIO {
             if (binding.perspective.hasChanges) {
-                val bitmap = files.bitmap(map.filename) ?: return@onIO
+                val bitmap = files.bitmap(map.imageFile.path) ?: return@onIO
                 val bounds =
                     percentBounds.toPixelBounds(bitmap.width.toFloat(), bitmap.height.toFloat())
                 val warped = bitmap.fixPerspective(bounds, true, Color.WHITE)
                 try {
-                    files.save(map.filename, warped, recycleOnSave = true)
+                    files.save(map.imageFile.path, warped, recycleOnSave = true)
                 } catch (e: IOException) {
                     return@onIO
                 }
 
                 // Delete the pdf file if it exists
-                files.delete(map.pdfFileName)
+                map.pdfFile?.let { files.delete(it.path) }
             }
             service.add(map.copy(georeference = map.georeference.copy(isWarpingCompleted = true)))
         }

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/MapCalibrationValidatorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/MapCalibrationValidatorTest.kt
@@ -18,8 +18,7 @@ internal class MapCalibrationValidatorTest {
         val map = PhotoMap(
             0,
             "",
-            "",
-            0,
+            listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             PhotoMapGeoreference(Size(1000f, 1000f))
         )
 
@@ -147,8 +146,7 @@ internal class MapCalibrationValidatorTest {
         return PhotoMap(
             0,
             "",
-            "",
-            0,
+            listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             PhotoMapGeoreference(
                 Size(1000f, 1000f),
                 isWarpingCompleted = true,

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/PhotoMapRotationServiceTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/PhotoMapRotationServiceTest.kt
@@ -54,8 +54,7 @@ internal class PhotoMapRotationServiceTest {
         val map = PhotoMap(
             0,
             "",
-            "",
-            0,
+            listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             PhotoMapGeoreference(
                 Size(100f, 200f),
                 isWarpingCompleted = true,

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapBoundsCalculatorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapBoundsCalculatorTest.kt
@@ -3,6 +3,7 @@ package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -86,8 +87,7 @@ internal class PhotoMapBoundsCalculatorTest {
         return PhotoMap(
             id = 0,
             name = "",
-            filename = "",
-            fileSizeBytes = 0,
+            files = listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             georeference = metadata.copy(
                 isWarpingCompleted = false,
                 rotation = rotation,

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMapTest.kt
@@ -2,6 +2,7 @@ package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps
 
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -67,8 +68,7 @@ internal class PhotoMapTest {
         return PhotoMap(
             id = 0,
             name = "",
-            filename = "",
-            fileSizeBytes = 0,
+            files = listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             georeference = metadata.copy(
                 isWarpingCompleted = false,
                 rotation = rotation,

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/projections/PhotoMapProjectionTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/projections/PhotoMapProjectionTest.kt
@@ -3,6 +3,7 @@ package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.projectio
 import com.kylecorry.sol.math.Vector2
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapCalibrationPoint
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapGeoreference
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapProjectionType
@@ -120,8 +121,7 @@ internal class PhotoMapProjectionTest {
         return PhotoMap(
             id = 0,
             name = "",
-            filename = "",
-            fileSizeBytes = 0,
+            files = listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)),
             georeference = metadata.copy(
                 isWarpingCompleted = false,
                 rotation = rotation,

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelectorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelectorTest.kt
@@ -76,7 +76,7 @@ class ActiveMapSelectorTest {
                     MapCalibrationPoint(boundary.northWest, PercentCoordinate(0f, 0f)),
                     MapCalibrationPoint(boundary.southEast, PercentCoordinate(1f, 1f))
                 )
-            ), null
+            )
         )
     }
 

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelectorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelectorTest.kt
@@ -3,6 +3,7 @@ package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.selection
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapCalibrationPoint
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapGeoreference
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PercentCoordinate
@@ -68,7 +69,7 @@ class ActiveMapSelectorTest {
 
     private fun map(id: Long, size: Size, boundary: CoordinateBounds): PhotoMap {
         return PhotoMap(
-            id, "", "", 0, PhotoMapGeoreference(
+            id, "", listOf(OfflineMapFile("", 0, PhotoMap.FILE_ROLE_IMAGE)), PhotoMapGeoreference(
                 size,
                 isWarpingCompleted = true,
                 calibrationPoints = listOf(

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/calibration/MapRotationCalculatorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/calibration/MapRotationCalculatorTest.kt
@@ -3,6 +3,7 @@ package com.kylecorry.trail_sense.tools.offline_maps.infrastructure.calibration
 import com.kylecorry.sol.math.MathExtensions.roundPlaces
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.units.Coordinate
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.MapCalibrationPoint
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapGeoreference
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PercentCoordinate
@@ -72,8 +73,7 @@ internal class MapRotationCalculatorTest {
         val map = PhotoMap(
             1,
             "",
-            "",
-            100,
+            listOf(OfflineMapFile("", 100, PhotoMap.FILE_ROLE_IMAGE)),
             PhotoMapGeoreference(
                 Size(400f, 200f),
                 isWarpingCompleted = true,


### PR DESCRIPTION
Creates an OfflineMapFile abstraction which encapsulates the files associated with an offline map. This allows both photo maps and trail maps to support multiple files. Each file has a role which allows determining which to use. Also folds in the isExternal and isAsset flags to avoid those leaking to the offline map models.

Issue: #3759