### PR TITLE
Add offline map interface

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMap.kt
@@ -1,0 +1,16 @@
+package com.kylecorry.trail_sense.tools.offline_maps.domain
+
+import com.kylecorry.sol.science.geology.CoordinateBounds
+import java.time.Instant
+
+interface OfflineMap : IMap {
+    val files: List<OfflineMapFile>
+    val visible: Boolean
+    val state: OfflineMapState
+
+    /**
+     * The bounds that the map covers. May be null when the state is Draft.
+     */
+    val bounds: CoordinateBounds?
+    val createdOn: Instant?
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapExtensions.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/OfflineMapExtensions.kt
@@ -1,0 +1,15 @@
+package com.kylecorry.trail_sense.tools.offline_maps.domain
+
+/**
+ * Get the total file size in bytes of the offline map
+ */
+fun OfflineMap.getFileSize(): Long {
+    return files.sumOf { it.sizeBytes }
+}
+
+/**
+ * Determines if this is an external map
+ */
+fun OfflineMap.isExternal(): Boolean {
+    return files.any { it.isExternal }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/PhotoMap.kt
@@ -1,12 +1,11 @@
 package com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps
 
-import com.kylecorry.luna.hooks.Hooks
 import com.kylecorry.sol.math.MathExtensions.roundNearestAngle
 import com.kylecorry.sol.math.geometry.Size
 import com.kylecorry.sol.science.geography.projections.IMapProjection
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.sol.units.Distance
-import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapState
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.projections.PhotoMapProjection
@@ -16,30 +15,29 @@ import java.time.Instant
 data class PhotoMap(
     override val id: Long,
     override val name: String,
-    val files: List<OfflineMapFile>,
+    override val files: List<OfflineMapFile>,
     val georeference: PhotoMapGeoreference,
     override val parentId: Long? = null,
-    val visible: Boolean = true,
-    val createdOn: Instant? = null,
-) : IMap {
+    override val visible: Boolean = true,
+    override val createdOn: Instant? = null,
+) : OfflineMap {
     override val isGroup = false
     override val count: Int? = null
 
     val imageFile = files.single { it.role == FILE_ROLE_IMAGE }
     val pdfFile = files.singleOrNull { it.role == FILE_ROLE_PDF }
-    val fileSizeBytes = files.sumOf { it.sizeBytes }
-
-    private val hooks = Hooks()
 
     /**
      * The projection onto the image/pdf.
      */
     val projection: IMapProjection by lazy { PhotoMapProjection(this) }
 
-    val state = if (MapCalibrationValidator.validate(this) == MapCalibrationValidationResult.Valid){
-        OfflineMapState.Ready
-    } else {
-        OfflineMapState.Draft
+    override val state by lazy {
+        if (MapCalibrationValidator.validate(this) == MapCalibrationValidationResult.Valid) {
+            OfflineMapState.Ready
+        } else {
+            OfflineMapState.Draft
+        }
     }
 
     /**
@@ -49,22 +47,23 @@ data class PhotoMap(
         PhotoMapProjection(this, usePdf = false)
     }
 
-    /**
-     * The distance per pixel of the image
-     * @return the distance per pixel or null if the map is not calibrated
-     */
-    fun distancePerPixel(): Distance? {
-
+    private val _distancePerPixel by lazy {
         if (state != OfflineMapState.Ready) {
-            return null
-        }
-
-        return hooks.memo("distance_per_pixel") {
+            null
+        } else {
             projection.distancePerPixel(
                 georeference.calibrationPoints[0].location,
                 georeference.calibrationPoints[1].location
             )
         }
+    }
+
+    /**
+     * The distance per pixel of the image
+     * @return the distance per pixel or null if the map is not calibrated
+     */
+    fun distancePerPixel(): Distance? {
+        return _distancePerPixel
     }
 
     /**
@@ -98,15 +97,7 @@ data class PhotoMap(
         }
     }
 
-    /**
-     * The boundary of the image
-     * @return the boundary or null if the map is not calibrated
-     */
-    fun boundary(): CoordinateBounds? {
-        return hooks.memo("boundary") {
-            PhotoMapBoundsCalculator().calculate(this)
-        }
-    }
+    override val bounds: CoordinateBounds? by lazy { PhotoMapBoundsCalculator().calculate(this) }
 
     companion object {
         // TODO: Make this based on meters per pixel

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelector.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/photo_maps/selection/ActiveMapSelector.kt
@@ -43,7 +43,7 @@ class ActiveMapSelector {
     }
 
     private fun contains(map: PhotoMap, location: Coordinate): Boolean {
-        return map.boundary()?.contains(location) == true
+        return map.bounds?.contains(location) == true
     }
 
     private fun isSimilarZoom(map: PhotoMap, base: PhotoMap, pct: Float): Boolean {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/sort/mappers/MapCreateTimeMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/sort/mappers/MapCreateTimeMapper.kt
@@ -3,15 +3,13 @@ package com.kylecorry.trail_sense.tools.offline_maps.domain.sort.mappers
 import com.kylecorry.trail_sense.shared.grouping.mapping.GroupMapper
 import com.kylecorry.trail_sense.shared.grouping.persistence.IGroupLoader
 import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
-import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
-import com.kylecorry.trail_sense.tools.offline_maps.domain.trail_maps.TrailMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMap
 
 class MapCreateTimeMapper(override val loader: IGroupLoader<IMap>) : GroupMapper<IMap, Long, Long>() {
 
     override suspend fun getValue(item: IMap): Long {
         val time = when (item) {
-            is PhotoMap -> item.createdOn
-            is TrailMap -> item.createdOn
+            is OfflineMap -> item.createdOn
             else -> null
         }
         return time?.toEpochMilli() ?: item.id

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/sort/mappers/MapMinimumDistanceMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/sort/mappers/MapMinimumDistanceMapper.kt
@@ -4,8 +4,7 @@ import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.shared.grouping.mapping.GroupMapper
 import com.kylecorry.trail_sense.shared.grouping.persistence.IGroupLoader
 import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
-import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
-import com.kylecorry.trail_sense.tools.offline_maps.domain.trail_maps.TrailMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMap
 
 class MapMinimumDistanceMapper(
     override val loader: IGroupLoader<IMap>,
@@ -15,17 +14,8 @@ class MapMinimumDistanceMapper(
 
     override suspend fun getValue(item: IMap): Float {
         val bounds = when (item) {
-            is PhotoMap -> {
-                item.boundary()
-            }
-
-            is TrailMap -> {
-                item.bounds
-            }
-
-            else -> {
-                null
-            }
+            is OfflineMap -> item.bounds
+            else -> null
         } ?: return Float.MAX_VALUE
         val location = locationProvider.invoke()
         val onMap = bounds.contains(location)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/trail_maps/TrailMap.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/domain/trail_maps/TrailMap.kt
@@ -1,29 +1,27 @@
 package com.kylecorry.trail_sense.tools.offline_maps.domain.trail_maps
 
 import com.kylecorry.sol.science.geology.CoordinateBounds
-import com.kylecorry.trail_sense.tools.offline_maps.domain.IMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapFile
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapState
+import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMap
 import java.time.Instant
 
 data class TrailMap(
     override val id: Long,
     override val name: String,
     val type: TrailMapFileType,
-    val files: List<OfflineMapFile>,
-    val createdOn: Instant,
-    val bounds: CoordinateBounds?,
+    override val files: List<OfflineMapFile>,
+    override val createdOn: Instant,
+    override val bounds: CoordinateBounds?,
     val attribution: String?,
-    val visible: Boolean,
+    override val visible: Boolean,
     override val parentId: Long? = null,
     val isAvailable: Boolean = true
-) : IMap {
+) : OfflineMap {
     override val isGroup = false
     override val count: Int? = null
-    val state = OfflineMapState.Ready
+    override val state = if (bounds == null) OfflineMapState.Draft else OfflineMapState.Ready
     val mapFile = files.single { it.role == FILE_ROLE_MAPSFORGE_MAP }
-    val isExternal = files.any { it.isExternal }
-    val fileSizeBytes = files.sumOf { it.sizeBytes }
 
     companion object {
         const val FILE_ROLE_MAPSFORGE_MAP = "mapsforge-map"

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/persistence/MapRepo.kt
@@ -18,6 +18,7 @@ import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapType
 import com.kylecorry.trail_sense.tools.offline_maps.domain.groups.MapGroup
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMapEntity
+import com.kylecorry.trail_sense.tools.offline_maps.domain.isExternal
 import com.kylecorry.trail_sense.tools.offline_maps.domain.trail_maps.TrailMap
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.groups.MapGroupEntity
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.trail_maps.MapFileTypeUtils
@@ -62,7 +63,7 @@ class MapRepo private constructor(context: Context) {
     }
 
     suspend fun delete(map: TrailMap) = onIO {
-        if (map.isExternal) {
+        if (map.isExternal()) {
             releaseExternalAccessIfUnused(map)
         } else {
             map.files.forEach {
@@ -74,7 +75,7 @@ class MapRepo private constructor(context: Context) {
     }
 
     suspend fun copyToAppStorage(map: TrailMap): TrailMap? = onIO {
-        if (!map.isExternal) {
+        if (!map.isExternal()) {
             return@onIO map
         }
 
@@ -153,8 +154,8 @@ class MapRepo private constructor(context: Context) {
     }
 
     private fun convertToMap(map: TrailMapEntity): TrailMap {
-        val newMap = map.toOfflineMapFile()
-        return if (newMap.isExternal) {
+        val newMap = map.toTrailMap()
+        return if (newMap.isExternal()) {
             newMap.copy(isAvailable = newMap.files.all { files.canRead(it.path) })
         } else {
             newMap

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/MapExportService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/MapExportService.kt
@@ -80,7 +80,7 @@ class MapExportService(
 
             val width = bitmap.width
             val height = bitmap.height
-            val bounds = map.boundary()
+            val bounds = map.bounds
 
             if (bounds == null) {
                 // No calibration, just generate a PDF containing the image

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/commands/MapCleanupCommand.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.kylecorry.luna.concurrency.onIO
 import com.kylecorry.trail_sense.shared.commands.CoroutineValueCommand
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import com.kylecorry.trail_sense.tools.offline_maps.domain.isExternal
 import com.kylecorry.trail_sense.tools.offline_maps.infrastructure.MapService
 
 class MapCleanupCommand(context: Context) : CoroutineValueCommand<Boolean> {
@@ -24,7 +25,7 @@ class MapCleanupCommand(context: Context) : CoroutineValueCommand<Boolean> {
 
     private suspend fun cleanupTrailMaps(): Boolean {
         // External maps don't have a file in app storage, so they can't be cleaned up
-        val maps = service.getAllTrailMaps().filter { !it.isExternal }
+        val maps = service.getAllTrailMaps().filter { !it.isExternal() }
         val allFiles = files.list(OFFLINE_MAPS_DIRECTORY).map { "$OFFLINE_MAPS_DIRECTORY/${it.name}" }
 
         // Delete files without a map

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapTileSourceSelector.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/photo_maps/tiles/PhotoMapTileSourceSelector.kt
@@ -109,7 +109,7 @@ class PhotoMapTileSourceSelector(
             .meters().value.toDouble() * 0.25
 
         val possibleMaps = sortedMaps.filter {
-            val boundary = it.boundary() ?: return@filter false
+            val boundary = it.bounds ?: return@filter false
             if (boundary == CoordinateBounds.world) {
                 return@filter true
             }
@@ -120,7 +120,7 @@ class PhotoMapTileSourceSelector(
 
         val firstContained = possibleMaps.firstOrNull {
             contains(
-                it.boundary() ?: return@firstOrNull false,
+                it.bounds ?: return@firstOrNull false,
                 bounds,
                 fullyContained = true
             )
@@ -128,7 +128,7 @@ class PhotoMapTileSourceSelector(
 
         val containedMaps = possibleMaps.filter {
             contains(
-                it.boundary() ?: return@filter false,
+                it.bounds ?: return@filter false,
                 bounds
             )
         }.take(maxLayers).toMutableList()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/trail_maps/persistence/TrailMapEntity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/infrastructure/trail_maps/persistence/TrailMapEntity.kt
@@ -29,7 +29,7 @@ data class TrailMapEntity(
     @ColumnInfo(name = "_id")
     var id: Long = 0
 
-    fun toOfflineMapFile(): TrailMap {
+    fun toTrailMap(): TrailMap {
         val hasLatitudeBounds = north != null && south != null
         val hasLongitudeBounds = east != null && west != null
         return TrailMap(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/PhotoMapListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/PhotoMapListItemMapper.kt
@@ -25,6 +25,7 @@ import com.kylecorry.trail_sense.shared.colors.AppColor
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapState
 import com.kylecorry.trail_sense.tools.offline_maps.domain.photo_maps.PhotoMap
+import com.kylecorry.trail_sense.tools.offline_maps.domain.getFileSize
 
 class PhotoMapListItemMapper(
     private val gps: IGPS,
@@ -38,7 +39,7 @@ class PhotoMapListItemMapper(
     private val files = FileSubsystem.getInstance(context)
 
     override fun map(value: PhotoMap): ListItem {
-        val onMap = value.boundary()?.contains(gps.location) ?: false
+        val onMap = value.bounds?.contains(gps.location) ?: false
         val icon = if (prefs.photoMaps.showMapPreviews) {
             AsyncListIcon(
                 lifecycleOwner,
@@ -56,7 +57,7 @@ class PhotoMapListItemMapper(
             icon = icon,
             subtitle = formatter.join(
                 value.createdOn?.let { formatter.formatDate(it.toZonedDateTime(), includeWeekDay = false) },
-                formatter.formatFileSize(value.fileSizeBytes),
+                formatter.formatFileSize(value.getFileSize()),
                 separator = FormatService.Separator.Dot
             ),
             tags = listOfNotNull(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/TrailMapListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/mappers/TrailMapListItemMapper.kt
@@ -15,6 +15,8 @@ import com.kylecorry.trail_sense.shared.CustomUiUtils.getPrimaryColor
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.colors.AppColor
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapState
+import com.kylecorry.trail_sense.tools.offline_maps.domain.getFileSize
+import com.kylecorry.trail_sense.tools.offline_maps.domain.isExternal
 import com.kylecorry.trail_sense.tools.offline_maps.domain.trail_maps.TrailMap
 
 class TrailMapListItemMapper(
@@ -32,7 +34,7 @@ class TrailMapListItemMapper(
             icon = ResourceListIcon(R.drawable.maps, AppColor.Gray.color, size = 48f, foregroundSize = 24f),
             subtitle = formatter.join(
                 formatter.formatDate(value.createdOn.toZonedDateTime(), includeWeekDay = false),
-                formatter.formatFileSize(value.fileSizeBytes),
+                formatter.formatFileSize(value.getFileSize()),
                 separator = FormatService.Separator.Dot
             ),
             tags = getTags(value),
@@ -79,7 +81,7 @@ class TrailMapListItemMapper(
             } else {
                 null
             },
-            if (value.isExternal) {
+            if (value.isExternal()) {
                 ListItemTag(
                     context.getString(R.string.map_external),
                     null,
@@ -111,7 +113,7 @@ class TrailMapListItemMapper(
             ListMenuItem(context.getString(R.string.move_to)) {
                 actionHandler(value, TrailMapAction.Move)
             },
-            if (value.isExternal && value.isAvailable) {
+            if (value.isExternal() && value.isAvailable) {
                 ListMenuItem(context.getString(R.string.copy_to_trail_sense)) {
                     actionHandler(value, TrailMapAction.CopyToAppStorage)
                 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/ViewPhotoMapFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/ViewPhotoMapFragment.kt
@@ -380,7 +380,7 @@ class ViewPhotoMapFragment : BoundFragment<FragmentPhotoMapsViewBinding>() {
         layerManager.pause(binding.map)
         this.map = map
         binding.map.minScale = 0f
-        val bounds = map.boundary() ?: CoordinateBounds(85.0, 180.0, -85.0, -180.0)
+        val bounds = map.bounds ?: CoordinateBounds(85.0, 180.0, -85.0, -180.0)
         binding.map.fitIntoView(bounds, paddingFactor = 1.05f)
         binding.map.constraintBounds = bounds
         binding.map.minScale = binding.map.scale


### PR DESCRIPTION
Adds the OfflineMap interface and consumes it on both PhotoMap and TrailMap. Renames some properties to match the domain terminology.

Issue: #3759