### PR TITLE
Enable plugins through experimental settings

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/plugins/PluginSubsystem.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/plugins/PluginSubsystem.kt
@@ -11,6 +11,7 @@ import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PersistedPlu
 import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PluginRegistrationRepo
 import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PluginRepo
 import com.kylecorry.trail_sense.shared.UserPreferences
+import com.kylecorry.trail_sense.shared.debugging.isPlayStoreBuild
 
 @Suppress("TooManyFunctions")
 class PluginSubsystem private constructor(private val context: Context) {
@@ -21,7 +22,7 @@ class PluginSubsystem private constructor(private val context: Context) {
     private val preferences = UserPreferences(context)
 
     fun arePluginsEnabled(): Boolean {
-        return preferences.arePluginsEnabled && !SafeMode.isEnabled()
+        return !isPlayStoreBuild() && preferences.arePluginsEnabled && !SafeMode.isEnabled()
     }
 
     // ======== Connection ========

--- a/app/src/main/java/com/kylecorry/trail_sense/plugins/PluginSubsystem.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/plugins/PluginSubsystem.kt
@@ -10,7 +10,7 @@ import com.kylecorry.trail_sense.plugins.infrastructure.PluginResourceServiceCon
 import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PersistedPlugin
 import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PluginRegistrationRepo
 import com.kylecorry.trail_sense.plugins.infrastructure.persistence.PluginRepo
-import com.kylecorry.trail_sense.shared.debugging.isDebug
+import com.kylecorry.trail_sense.shared.UserPreferences
 
 @Suppress("TooManyFunctions")
 class PluginSubsystem private constructor(private val context: Context) {
@@ -18,9 +18,10 @@ class PluginSubsystem private constructor(private val context: Context) {
     private val pluginLoader = PluginLoader(context)
     private val pluginRepo = PluginRepo.getInstance(context)
     private val pluginRegistrationRepo = PluginRegistrationRepo.getInstance(context)
+    private val preferences = UserPreferences(context)
 
     fun arePluginsEnabled(): Boolean {
-        return isDebug() && !SafeMode.isEnabled()
+        return preferences.arePluginsEnabled && !SafeMode.isEnabled()
     }
 
     // ======== Connection ========
@@ -62,6 +63,9 @@ class PluginSubsystem private constructor(private val context: Context) {
      * Connect a plugin
      */
     suspend fun connect(plugin: Plugin) {
+        if (!arePluginsEnabled()) {
+            return
+        }
         pluginRepo.upsert(PersistedPlugin(plugin.packageId, plugin.signatureString()))
     }
 
@@ -82,6 +86,9 @@ class PluginSubsystem private constructor(private val context: Context) {
      * Determines if a plugin is installed and connected
      */
     suspend fun isConnected(packageId: String): Boolean {
+        if (!arePluginsEnabled()) {
+            return false
+        }
         val plugin = pluginLoader.getPlugin(packageId) ?: return false
         return pluginRepo.get(packageId)?.signature == plugin.signatureString()
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/ExperimentalSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/ExperimentalSettingsFragment.kt
@@ -9,6 +9,7 @@ import com.kylecorry.sol.science.meteorology.forecast.ForecastSource
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem.GroupBehavior
 import com.kylecorry.trail_sense.shared.debugging.isDebug
+import com.kylecorry.trail_sense.shared.debugging.isPlayStoreBuild
 import com.kylecorry.trail_sense.shared.requireMainActivity
 import com.kylecorry.trail_sense.shared.sensors.SensorService
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
@@ -23,6 +24,7 @@ class ExperimentalSettingsFragment : AndromedaPreferenceFragment() {
         val hasCompass = sensors.hasCompass()
 
         preference(R.string.pref_experimental_metal_direction)?.isVisible = hasGyro && hasCompass
+        preference(R.string.pref_plugins_enabled)?.isVisible = !isPlayStoreBuild()
 
         onClick(preference(R.string.pref_cliff_height_enabled)) {
             requireMainActivity().updateBottomNavigation()

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/ui/SettingsFragment.kt
@@ -39,7 +39,7 @@ class SettingsFragment : AndromedaPreferenceFragment() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
 
-        preference(R.string.pref_plugins_settings)?.isVisible = plugins.arePluginsEnabled()
+        updatePluginSettingsVisibility()
 
         for (nav in navigationMap) {
             navigateOnClick(preference(nav.key), nav.value)
@@ -86,6 +86,15 @@ class SettingsFragment : AndromedaPreferenceFragment() {
             }
             toolCategoryPreference?.addPreference(preference)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updatePluginSettingsVisibility()
+    }
+
+    private fun updatePluginSettingsVisibility() {
+        preference(R.string.pref_plugins_settings)?.isVisible = plugins.arePluginsEnabled()
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
@@ -112,6 +112,12 @@ class UserPreferences(ctx: Context) : IDeclinationPreferences {
         false
     )
 
+    val arePluginsEnabled by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_plugins_enabled),
+        false
+    )
+
     val distanceUnits by StringEnumPreference(
         cache,
         getString(R.string.pref_distance_units),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -783,6 +783,7 @@
     <string name="pref_unit_settings" translatable="false">pref_unit_settings</string>
     <string name="pref_experimental_metal_direction" translatable="false">pref_experimental_metal_direction</string>
     <string name="pref_experimental_metal_direction_title">Show metal direction</string>
+    <string name="pref_plugins_enabled" translatable="false">pref_plugins_enabled</string>
     <string name="pref_experimental_settings" translatable="false">pref_experimental_settings</string>
     <string name="pref_sensor_settings" translatable="false">pref_sensor_settings</string>
     <string name="location_mocked">Using mocked location</string>

--- a/app/src/main/res/xml/experimental_preferences.xml
+++ b/app/src/main/res/xml/experimental_preferences.xml
@@ -17,6 +17,13 @@
             app:title="@string/pref_experimental_metal_direction_title" />
 
         <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_plugins_enabled"
+            app:singleLineTitle="false"
+            app:title="@string/plugins" />
+
+        <SwitchPreferenceCompat
             android:summary="@string/camera"
             app:defaultValue="false"
             app:disableDependentsState="true"

--- a/docs/plugins/registration.md
+++ b/docs/plugins/registration.md
@@ -1,6 +1,6 @@
 # Plugin registration
 
-NOTE: Plugins are only available in debug mode right now and are not production ready. The interfaces are prone to changing. This message will be removed once plugins are stable.
+NOTE: Plugins are only available when enabled in Settings > Experimental and are not production ready.
 
 Trail Sense discovers plugin resource services through the Android service action `com.kylecorry.trail_sense.PLUGIN_SERVICE`.
 

--- a/guides/en-US/guide_tool_map_layers.txt
+++ b/guides/en-US/guide_tool_map_layers.txt
@@ -6,7 +6,7 @@ On the layer settings panel, the higher up a layer is in the list, the more "on 
 
 Click on the layer's name to expand its settings.
 
-You can use the "Additional layers" button at the bottom of the layers list to add additional layers.
+You can use the "Additional layers" button at the bottom of the layers list to add additional layers. Connected plugins may also provide additional map layers. Plugins are experimental and must be enabled in Settings > Experimental > Plugins, then connected from Settings > Plugins.
 
 Each layer has the following settings:
 

--- a/guides/en-US/guide_tool_settings.txt
+++ b/guides/en-US/guide_tool_settings.txt
@@ -174,6 +174,23 @@ Some tools such as Navigation and Astronomy display error banners at the top of 
 ## Experimental
 Experimental features can be enabled in Settings > Experimental. These features are not ready for general use and may not work as expected.
 
+### Plugins
+Plugins allow other installed apps to add features to Trail Sense. Right now they are limited to additional map layers.
+
+To use plugins, enable Settings > Experimental > Plugins. After enabling plugins, a Plugins page will appear in Settings where you can connect or disconnect available plugins.
+
+Connect a plugin by clicking on it in the "Available plugins" section. Only connect plugins that you trust. You can click on a connected plugin to see details about what features it adds, reload it, open its app, or disconnect.
+
+**Plugins are not currently available on the Google Play version of Trail Sense.**
+
+#### Privacy and Security
+
+Trail Sense will not communicate with plugins you haven't explicitly connected. Once connected, Trail Sense asks the plugin what features it adds and does not send any of your data over.
+
+When a map layer plugin is connected and the layer is enabled on the map, Trail Sense checks to make sure it has the precise location permission granted. If it does not, you will need to grant it to the plugin to use and Trail Sense will not load map data from it until that is done. If that is granted, Trail Sense will send the viewport bounds of the map to the plugin to load features and tiles.
+
+If the plugin's signature changes, it will be disconnected, and you will need to reconnect.
+
 ### Notification grouping
 Android 16 introduces forced notification grouping for apps. This normally puts all of Trail Sense's notifications into one group, which can be hard to read at a glance.
 


### PR DESCRIPTION
Allows users to enable plugins through Experimental settings. Disabled on the playStore build variant (see #3868). 

Issue: #3866