### PR TITLE
Improve tile layer performance

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -15,7 +15,7 @@ class ImageTile(
 
     private val lock = ReentrantLock()
 
-    private var _loadFunction: (suspend () -> Bitmap?)? = loadFunction
+    @Volatile private var _loadFunction: (suspend () -> Bitmap?)? = loadFunction
 
     var loadingStartTime: Long? = null
     fun getAlpha(): Int {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -1,22 +1,24 @@
 package com.kylecorry.trail_sense.shared.map_layers.tiles
 
 import android.graphics.Bitmap
-import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.withLock
 
 class ImageTile(
     val key: String,
     val tile: Tile,
-    private var image: Bitmap? = null,
+    @Volatile private var image: Bitmap? = null,
     @Volatile var state: TileState = TileState.Idle,
     private val shouldFadeIn: Boolean = true,
     loadFunction: (suspend () -> Bitmap?)?
 ) {
 
-    private val lock = ReentrantLock()
+    private val lock = ReentrantReadWriteLock()
 
-    @Volatile private var _loadFunction: (suspend () -> Bitmap?)? = loadFunction
+    @Volatile
+    private var _loadFunction: (suspend () -> Bitmap?)? = loadFunction
 
+    @Volatile
     var loadingStartTime: Long? = null
     fun getAlpha(): Int {
         if (!shouldFadeIn) {
@@ -38,24 +40,19 @@ class ImageTile(
     }
 
     fun hasImage(): Boolean {
-        if (!lock.tryLock()) {
-            return false
-        }
-        return try {
+        return lock.readLock().withLock {
             image != null
-        } finally {
-            lock.unlock()
         }
     }
 
     fun setLoader(loader: (suspend () -> Bitmap?)?) {
-        lock.withLock {
+        lock.writeLock().withLock {
             _loadFunction = loader
         }
     }
 
     fun invalidate() {
-        lock.withLock {
+        lock.writeLock().withLock {
             state = TileState.Stale
             _loadFunction = null
         }
@@ -63,7 +60,7 @@ class ImageTile(
 
     suspend fun load() {
         var wasIdle = false
-        val loader = lock.withLock {
+        val loader = lock.writeLock().withLock {
             if (_loadFunction == null) {
                 state = TileState.Stale
                 return
@@ -77,7 +74,7 @@ class ImageTile(
         var wasSuccess = false
         try {
             val newImage = loader?.invoke()
-            lock.withLock {
+            lock.writeLock().withLock {
                 image?.recycle()
                 image = newImage
                 hasImage = image != null
@@ -85,7 +82,7 @@ class ImageTile(
             wasSuccess = true
         } catch (e: Throwable) {
             e.printStackTrace()
-            lock.withLock {
+            lock.writeLock().withLock {
                 image?.recycle()
                 image = null
             }
@@ -94,7 +91,7 @@ class ImageTile(
             loadingStartTime = System.currentTimeMillis()
         }
 
-        lock.withLock {
+        lock.writeLock().withLock {
             if (state == TileState.Stale) {
                 return
             }
@@ -108,25 +105,13 @@ class ImageTile(
     }
 
     fun withImage(block: (image: Bitmap?) -> Unit) {
-        lock.withLock {
+        lock.readLock().withLock {
             block(image)
-        }
-    }
-
-    fun tryWithImage(block: (image: Bitmap?) -> Unit): Boolean {
-        if (!lock.tryLock()) {
-            return false
-        }
-        return try {
-            block(image)
-            true
-        } finally {
-            lock.unlock()
         }
     }
 
     fun recycle() {
-        lock.withLock {
+        lock.writeLock().withLock {
             image?.recycle()
             image = null
             state = TileState.Idle

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -2,7 +2,9 @@ package com.kylecorry.trail_sense.shared.map_layers.tiles
 
 import android.graphics.Bitmap
 import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
 import kotlin.concurrent.withLock
+import kotlin.concurrent.write
 
 class ImageTile(
     val key: String,
@@ -40,19 +42,19 @@ class ImageTile(
     }
 
     fun hasImage(): Boolean {
-        return lock.readLock().withLock {
+        return lock.read {
             image != null
         }
     }
 
     fun setLoader(loader: (suspend () -> Bitmap?)?) {
-        lock.writeLock().withLock {
+        lock.write {
             _loadFunction = loader
         }
     }
 
     fun invalidate() {
-        lock.writeLock().withLock {
+        lock.write {
             state = TileState.Stale
             _loadFunction = null
         }
@@ -60,7 +62,7 @@ class ImageTile(
 
     suspend fun load() {
         var wasIdle = false
-        val loader = lock.writeLock().withLock {
+        val loader = lock.write {
             if (_loadFunction == null) {
                 state = TileState.Stale
                 return
@@ -74,7 +76,7 @@ class ImageTile(
         var wasSuccess = false
         try {
             val newImage = loader?.invoke()
-            lock.writeLock().withLock {
+            lock.write {
                 image?.recycle()
                 image = newImage
                 hasImage = image != null
@@ -82,7 +84,7 @@ class ImageTile(
             wasSuccess = true
         } catch (e: Throwable) {
             e.printStackTrace()
-            lock.writeLock().withLock {
+            lock.write {
                 image?.recycle()
                 image = null
             }
@@ -91,7 +93,7 @@ class ImageTile(
             loadingStartTime = System.currentTimeMillis()
         }
 
-        lock.writeLock().withLock {
+        lock.write {
             if (state == TileState.Stale) {
                 return
             }
@@ -105,13 +107,13 @@ class ImageTile(
     }
 
     fun withImage(block: (image: Bitmap?) -> Unit) {
-        lock.readLock().withLock {
+        lock.read {
             block(image)
         }
     }
 
     fun recycle() {
-        lock.writeLock().withLock {
+        lock.write {
             image?.recycle()
             image = null
             state = TileState.Idle

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -1,17 +1,19 @@
 package com.kylecorry.trail_sense.shared.map_layers.tiles
 
 import android.graphics.Bitmap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class ImageTile(
     val key: String,
     val tile: Tile,
     private var image: Bitmap? = null,
-    var state: TileState = TileState.Idle,
+    @Volatile var state: TileState = TileState.Idle,
     private val shouldFadeIn: Boolean = true,
     loadFunction: (suspend () -> Bitmap?)?
 ) {
 
-    private val lock = Any()
+    private val lock = ReentrantLock()
 
     private var _loadFunction: (suspend () -> Bitmap?)? = loadFunction
 
@@ -36,19 +38,24 @@ class ImageTile(
     }
 
     fun hasImage(): Boolean {
-        synchronized(lock) {
-            return image != null
+        if (!lock.tryLock()) {
+            return false
+        }
+        return try {
+            image != null
+        } finally {
+            lock.unlock()
         }
     }
 
     fun setLoader(loader: (suspend () -> Bitmap?)?) {
-        synchronized(lock) {
+        lock.withLock {
             _loadFunction = loader
         }
     }
 
     fun invalidate() {
-        synchronized(lock) {
+        lock.withLock {
             state = TileState.Stale
             _loadFunction = null
         }
@@ -56,7 +63,7 @@ class ImageTile(
 
     suspend fun load() {
         var wasIdle = false
-        val loader = synchronized(lock) {
+        val loader = lock.withLock {
             if (_loadFunction == null) {
                 state = TileState.Stale
                 return
@@ -70,7 +77,7 @@ class ImageTile(
         var wasSuccess = false
         try {
             val newImage = loader?.invoke()
-            synchronized(lock) {
+            lock.withLock {
                 image?.recycle()
                 image = newImage
                 hasImage = image != null
@@ -78,7 +85,7 @@ class ImageTile(
             wasSuccess = true
         } catch (e: Throwable) {
             e.printStackTrace()
-            synchronized(lock) {
+            lock.withLock {
                 image?.recycle()
                 image = null
             }
@@ -87,7 +94,7 @@ class ImageTile(
             loadingStartTime = System.currentTimeMillis()
         }
 
-        synchronized(lock) {
+        lock.withLock {
             if (state == TileState.Stale) {
                 return
             }
@@ -101,13 +108,25 @@ class ImageTile(
     }
 
     fun withImage(block: (image: Bitmap?) -> Unit) {
-        synchronized(lock) {
+        lock.withLock {
             block(image)
         }
     }
 
+    fun tryWithImage(block: (image: Bitmap?) -> Unit): Boolean {
+        if (!lock.tryLock()) {
+            return false
+        }
+        return try {
+            block(image)
+            true
+        } finally {
+            lock.unlock()
+        }
+    }
+
     fun recycle() {
-        synchronized(lock) {
+        lock.withLock {
             image?.recycle()
             image = null
             state = TileState.Idle

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
@@ -1,8 +1,11 @@
 package com.kylecorry.trail_sense.shared.map_layers.tiles
 
 import androidx.collection.LruCache
+import java.util.concurrent.ConcurrentHashMap
 
 class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(maxSize) {
+
+    private val entries = ConcurrentHashMap<String, ImageTile>()
 
     override fun entryRemoved(
         evicted: Boolean,
@@ -11,6 +14,7 @@ class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(
         newValue: ImageTile?
     ) {
         super.entryRemoved(evicted, key, oldValue, newValue)
+        entries.remove(key, oldValue)
         oldValue.recycle()
     }
 
@@ -19,7 +23,7 @@ class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(
     }
 
     fun peek(tile: Tile): ImageTile? {
-        return snapshot()[getKey(tile)]
+        return entries[getKey(tile)]
     }
 
     fun getOrPut(key: String, provider: () -> ImageTile): ImageTile {
@@ -30,6 +34,7 @@ class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(
             }
             val newValue = provider()
             put(key, newValue)
+            entries[key] = newValue
             return newValue
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -19,6 +19,8 @@ import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.map_layers.tiles.infrastructure.persistance.PersistentTileCache
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.MapLayerParams
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 
 class TileLoader(
@@ -31,6 +33,7 @@ class TileLoader(
 ) {
 
     val tileCache = TileCache(tag ?: "", 256)
+    private val borderPopulationLock = Mutex()
 
     private val persistentCache =
         if (key != null) getAppService<PersistentTileCache>() else null
@@ -53,8 +56,10 @@ class TileLoader(
     init {
         // TODO: This should be handled by a higher level component
         tileQueue.setChangeListener { imageTile ->
-            tryOrLog {
-                populateBorderAndNeighbors(imageTile)
+            borderPopulationLock.withLock {
+                tryOrLog {
+                    populateBorderAndNeighbors(imageTile)
+                }
             }
             updateListener()
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -19,8 +19,6 @@ import com.kylecorry.trail_sense.main.getAppService
 import com.kylecorry.trail_sense.shared.map_layers.tiles.infrastructure.persistance.PersistentTileCache
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.MapLayerParams
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 
 class TileLoader(
@@ -33,7 +31,6 @@ class TileLoader(
 ) {
 
     val tileCache = TileCache(tag ?: "", 256)
-    private val borderPopulationLock = Mutex()
 
     private val persistentCache =
         if (key != null) getAppService<PersistentTileCache>() else null
@@ -56,10 +53,8 @@ class TileLoader(
     init {
         // TODO: This should be handled by a higher level component
         tileQueue.setChangeListener { imageTile ->
-            borderPopulationLock.withLock {
-                tryOrLog {
-                    populateBorderAndNeighbors(imageTile)
-                }
+            tryOrLog {
+                populateBorderAndNeighbors(imageTile)
             }
             updateListener()
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
@@ -9,7 +9,7 @@ import kotlin.math.log
 class TileQueue {
     // Enable this to log what tiles are being loaded
     private val shouldLog = false
-    private var changeListener: (tile: ImageTile) -> Unit = {}
+    private var changeListener: suspend (tile: ImageTile) -> Unit = {}
     private val loadingKeys = mutableSetOf<String>()
     private val queuedKeys = mutableSetOf<String>()
     private val loadingCount = AtomicInteger(0)
@@ -125,7 +125,7 @@ class TileQueue {
         }
     }
 
-    private fun onStateChange(tile: ImageTile) {
+    private suspend fun onStateChange(tile: ImageTile) {
         synchronized(loadingKeys) {
             if (loadingKeys.remove(tile.key)) {
                 loadingCount.decrementAndGet()
@@ -152,7 +152,7 @@ class TileQueue {
         return 65536 * log(resolution, 10.0) + distance / resolution
     }
 
-    fun setChangeListener(listener: (tile: ImageTile) -> Unit) {
+    fun setChangeListener(listener: suspend (tile: ImageTile) -> Unit) {
         changeListener = listener
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -23,6 +23,7 @@ import com.kylecorry.sol.math.geometry.Rectangle
 import com.kylecorry.sol.math.interpolation.Interpolation
 import com.kylecorry.sol.science.geology.CoordinateBounds
 import com.kylecorry.trail_sense.main.errors.SafeMode
+import com.kylecorry.trail_sense.shared.concurrency.CustomDispatchers
 import com.kylecorry.trail_sense.shared.getBounds
 import com.kylecorry.trail_sense.shared.map_layers.MapLayerBackgroundTask
 import com.kylecorry.trail_sense.shared.map_layers.preferences.repo.DefaultMapLayerDefinitions
@@ -36,6 +37,7 @@ import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IAsyncLayer
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IMapView
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IMapViewProjection
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
+import kotlinx.coroutines.CoroutineScope
 import java.time.Duration
 import java.time.Instant
 import kotlin.math.max
@@ -85,8 +87,11 @@ open class TileMapLayer<T : TileSource>(
     protected var layerPreferences: Bundle = Bundle()
     private var featureId: String? = null
 
-    private val loadTimer = CoroutineTimer {
-        queue.load(maxOf(4, Runtime.getRuntime().availableProcessors()))
+    private val loadTimer = CoroutineTimer(
+        scope = CoroutineScope(tileLoadDispatcher),
+        observeOn = tileLoadDispatcher
+    ) {
+        queue.load(maxConcurrentLoads)
         isLoaded = queue.isEmpty()
     }
     private val refreshTimer = refreshInterval?.let { CoroutineTimer { refresh() } }
@@ -557,5 +562,10 @@ open class TileMapLayer<T : TileSource>(
     companion object {
         const val MAX_TILES = 150
         private const val TILE_BORDER_PIXELS = 2
+        private val maxConcurrentLoads = maxOf(4, Runtime.getRuntime().availableProcessors())
+        private val tileLoadDispatcher = CustomDispatchers.newFixedThreadDispatcher(
+            threads = maxConcurrentLoads,
+            name = "TileMapLayer"
+        )
     }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -214,8 +214,8 @@ open class TileMapLayer<T : TileSource>(
         }
 
         getTilesToRender(desiredTiles).forEach { renderTile ->
-            renderTile.imageTile.tryWithImage { bitmap ->
-                bitmap ?: return@tryWithImage
+            renderTile.imageTile.withImage { bitmap ->
+                bitmap ?: return@withImage
                 tryOrLog {
                     val clipTile = renderTile.clipTo
                     if (clipTile != null) {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -209,8 +209,8 @@ open class TileMapLayer<T : TileSource>(
         }
 
         getTilesToRender(desiredTiles).forEach { renderTile ->
-            renderTile.imageTile.withImage { bitmap ->
-                bitmap ?: return@withImage
+            renderTile.imageTile.tryWithImage { bitmap ->
+                bitmap ?: return@tryWithImage
                 tryOrLog {
                     val clipTile = renderTile.clipTo
                     if (clipTile != null) {


### PR DESCRIPTION
Improves tile layer performance by moving all loading / border population off of the main thread. It also switches to a read-write lock so that the UI does not get blocked while the tile borders are being populated using neighbor bitmaps.

It also changes the TileCache to use a separate hashmap for maintaining the current state of the LRU. This allows avoiding the expensive snapshot call on the LRU which allocates extra memory every time we peek (not a problem outside of GrapheneOS). It allows peek to be O(1) instead of O(n)

Issue: #3872