### PR TITLE
Improve tile queue locking

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LazyPriorityQueue.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LazyPriorityQueue.kt
@@ -3,18 +3,21 @@ package com.kylecorry.trail_sense.shared.map_layers.tiles
 import java.util.PriorityQueue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class LazyPriorityQueue<T : Any>(initialCapacity: Int, comparator: Comparator<T>) {
     private val stagingQueue = ConcurrentLinkedQueue<T>()
     private val priorityQueue = PriorityQueue(initialCapacity, comparator)
     private val count = AtomicInteger(0)
     private val stagedCount = AtomicInteger(0)
+    private val priorityQueueLock = ReentrantLock()
 
     @Volatile
     private var prioritiesChanged = false
 
     /**
-     * Enqueue an item into the priority queue. This operation is thread safe.
+     * Enqueue an item into the priority queue.
      */
     fun enqueue(item: T) {
         stagingQueue.add(item)
@@ -31,9 +34,8 @@ class LazyPriorityQueue<T : Any>(initialCapacity: Int, comparator: Comparator<T>
 
     /**
      * Dequeue the highest priority items from the queue
-     * This is not thread safe
      */
-    fun dequeue(count: Int = 1): List<T> {
+    fun dequeue(count: Int = 1): List<T> = priorityQueueLock.withLock {
         // Read the staging queue
         val stagedItems = (0 until stagedCount.get()).mapNotNull {
             val item = stagingQueue.poll()
@@ -67,9 +69,8 @@ class LazyPriorityQueue<T : Any>(initialCapacity: Int, comparator: Comparator<T>
 
     /**
      * Clear the queue
-     * This is not thread safe
      */
-    fun clear() {
+    fun clear() = priorityQueueLock.withLock {
         stagingQueue.clear()
         priorityQueue.clear()
         count.set(0)

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
@@ -4,10 +4,8 @@ import android.util.Log
 import com.kylecorry.luna.concurrency.Parallel
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IMapViewProjection
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
-import kotlin.concurrent.withLock
 import kotlin.concurrent.write
 import kotlin.math.log
 
@@ -29,8 +27,6 @@ class TileQueue {
 
     @Volatile
     private var desiredTiles: Set<Tile>? = null
-
-    private val dequeueLock = ReentrantLock()
 
     fun setMapProjection(projection: IMapViewProjection) {
         mapProjection = projection
@@ -62,7 +58,7 @@ class TileQueue {
     }
 
     fun clear() {
-        dequeueLock.withLock { queue.clear() }
+        queue.clear()
         synchronized(queuedKeys) {
             queuedKeys.clear()
         }
@@ -77,7 +73,7 @@ class TileQueue {
     }
 
     private fun dequeue(): ImageTile? {
-        val tile = dequeueLock.withLock { queue.dequeue().firstOrNull() }
+        val tile = queue.dequeue().firstOrNull()
         if (tile != null) {
             synchronized(queuedKeys) {
                 queuedKeys.remove(tile.key)

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileQueue.kt
@@ -5,7 +5,10 @@ import com.kylecorry.luna.concurrency.Parallel
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.IMapViewProjection
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
 import kotlin.concurrent.withLock
+import kotlin.concurrent.write
 import kotlin.math.log
 
 class TileQueue {
@@ -13,6 +16,7 @@ class TileQueue {
     private val shouldLog = false
     private var changeListener: suspend (tile: ImageTile) -> Unit = {}
     private val loadingKeys = mutableSetOf<String>()
+    private val loadingLock = ReentrantReadWriteLock()
     private val queuedKeys = mutableSetOf<String>()
     private val loadingCount = AtomicInteger(0)
 
@@ -42,7 +46,7 @@ class TileQueue {
         if (state != TileState.Idle && state != TileState.Stale) {
             return
         }
-        synchronized(loadingKeys) {
+        loadingLock.read {
             if (loadingKeys.contains(tile.key)) {
                 return
             }
@@ -62,7 +66,7 @@ class TileQueue {
         synchronized(queuedKeys) {
             queuedKeys.clear()
         }
-        synchronized(loadingKeys) {
+        loadingLock.write {
             loadingKeys.clear()
             loadingCount.set(0)
         }
@@ -95,7 +99,7 @@ class TileQueue {
             val key = tile.key
             val tileState = tile.state
             if (tileState == TileState.Idle || tileState == TileState.Stale) {
-                val shouldLoad = synchronized(loadingKeys) {
+                val shouldLoad = loadingLock.write {
                     loadingKeys.add(key).also {
                         if (it) {
                             loadingCount.incrementAndGet()
@@ -119,7 +123,7 @@ class TileQueue {
                 onStateChange(it)
             }
         } finally {
-            synchronized(loadingKeys) {
+            loadingLock.write {
                 jobs.forEach {
                     if (loadingKeys.remove(it.key)) {
                         loadingCount.decrementAndGet()
@@ -130,7 +134,7 @@ class TileQueue {
     }
 
     private suspend fun onStateChange(tile: ImageTile) {
-        synchronized(loadingKeys) {
+        loadingLock.write {
             if (loadingKeys.remove(tile.key)) {
                 loadingCount.decrementAndGet()
             }


### PR DESCRIPTION
Make priority queue thread safe by locking the writes to the priority queue and use a read-write lock for tile queue loading key tracking.

Issue: #3872