### PR TITLE
pedometer: better speed and pace calculations

### DIFF
--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
@@ -46,6 +46,12 @@ class ToolPedometerTest : ToolTestBase(Tools.PEDOMETER) {
         hasText(R.id.pedometer_average_speed, "-")
         hasText(R.id.pedometer_average_speed, string(R.string.average_speed))
 
+        hasText(R.id.pedometer_pace, "-")
+        hasText(R.id.pedometer_pace, string(R.string.current_pace))
+
+        hasText(R.id.pedometer_average_pace, "-")
+        hasText(R.id.pedometer_average_pace, string(R.string.average_pace))
+
         hasText(R.id.pedometer_active_time, string(R.string.duration_second_format, 0))
         hasText(R.id.pedometer_active_time, string(R.string.active_time))
 

--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
@@ -52,9 +52,6 @@ class ToolPedometerTest : ToolTestBase(Tools.PEDOMETER) {
         hasText(R.id.pedometer_average_pace, "-")
         hasText(R.id.pedometer_average_pace, string(R.string.average_pace))
 
-        hasText(R.id.pedometer_active_time, string(R.string.duration_second_format, 0))
-        hasText(R.id.pedometer_active_time, string(R.string.active_time))
-
         hasText(R.id.play_bar_title, string(R.string.off))
 
         click(R.id.play_btn)
@@ -68,7 +65,13 @@ class ToolPedometerTest : ToolTestBase(Tools.PEDOMETER) {
         click(R.id.reset_btn)
         clickOk()
 
-        hasText(R.id.current_session_time, Regex("\\d+:\\d+ [AP]M - ${string(R.string.now)}"))
+        hasText(
+            R.id.current_session_time,
+            Regex(
+                "\\d+:\\d+ [AP]M - ${string(R.string.now)} " +
+                        "\\(${string(R.string.active_duration, ".*")}\\)"
+            )
+        )
 
         click(toolbarButton(R.id.pedometer_title, Side.Right))
         input(R.id.amount, "0")

--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/pedometer/ToolPedometerTest.kt
@@ -46,6 +46,9 @@ class ToolPedometerTest : ToolTestBase(Tools.PEDOMETER) {
         hasText(R.id.pedometer_average_speed, "-")
         hasText(R.id.pedometer_average_speed, string(R.string.average_speed))
 
+        hasText(R.id.pedometer_active_time, string(R.string.duration_second_format, 0))
+        hasText(R.id.pedometer_active_time, string(R.string.active_time))
+
         hasText(R.id.play_bar_title, string(R.string.off))
 
         click(R.id.play_btn)

--- a/app/src/main/java/com/kylecorry/trail_sense/main/persistence/AppDatabase.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/persistence/AppDatabase.kt
@@ -69,7 +69,7 @@ import com.kylecorry.trail_sense.tools.weather.infrastructure.persistence.Pressu
 @Suppress("LocalVariableName")
 @Database(
     entities = [PackItemEntity::class, Note::class, WaypointEntity::class, PressureReadingEntity::class, BeaconEntity::class, BeaconGroupEntity::class, PhotoMapEntity::class, BatteryReadingEntity::class, PackEntity::class, CloudReadingEntity::class, PathEntity::class, TideTableEntity::class, TideTableRowEntity::class, PathGroupEntity::class, LightningStrikeEntity::class, MapGroupEntity::class, TideConstituentEntry::class, FieldGuidePageEntity::class, FieldGuideSightingEntity::class, DigitalElevationModelEntity::class, NavigationBearingEntity::class, CachedTileEntity::class, PluginEntity::class, PluginRegistrationEntity::class, TrailMapEntity::class, StepTrackingPeriodEntity::class, StepCountBucketEntity::class],
-    version = 57,
+    version = 58,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -562,6 +562,12 @@ abstract class AppDatabase : RoomDatabase() {
                 }
             }
 
+            val MIGRATION_57_58 = object : Migration(57, 58) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE `step_count_buckets` ADD COLUMN `active_time` INTEGER NOT NULL DEFAULT 0")
+                }
+            }
+
             return Room.databaseBuilder(context, AppDatabase::class.java, "trail_sense")
                 .addMigrations(
                     MIGRATION_1_2,
@@ -619,7 +625,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_53_54,
                     MIGRATION_54_55,
                     MIGRATION_55_56,
-                    MIGRATION_56_57
+                    MIGRATION_56_57,
+                    MIGRATION_57_58
                 )
                 // TODO: Temporary for the android tests, will remove once AppDatabase is injected with hilt
                 .allowMainThreadQueries()

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/IPedometerPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/IPedometerPreferences.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.settings.infrastructure
 
 import com.kylecorry.sol.units.Distance
+import com.kylecorry.trail_sense.tools.pedometer.domain.AveragePaceTimeMode
 import java.time.Duration
 
 interface IPedometerPreferences {
@@ -10,4 +11,5 @@ interface IPedometerPreferences {
     var alertDistance: Distance?
     val useAlarmForDistanceAlert: Boolean
     var stepHistory: Duration
+    val averagePaceTimeMode: AveragePaceTimeMode
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PedometerPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/settings/infrastructure/PedometerPreferences.kt
@@ -2,8 +2,10 @@ package com.kylecorry.trail_sense.settings.infrastructure
 
 import android.content.Context
 import com.kylecorry.andromeda.preferences.BooleanPreference
+import com.kylecorry.andromeda.preferences.StringEnumPreference
 import com.kylecorry.sol.units.Distance
 import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.tools.pedometer.domain.AveragePaceTimeMode
 import java.time.Duration
 
 class PedometerPreferences(context: Context) : PreferenceRepo(context), IPedometerPreferences {
@@ -45,6 +47,13 @@ class PedometerPreferences(context: Context) : PreferenceRepo(context), IPedomet
         cache,
         getString(R.string.pref_pedometer_use_alarm_for_distance_alert),
         false
+    )
+
+    override val averagePaceTimeMode by StringEnumPreference(
+        cache,
+        getString(R.string.pref_pedometer_average_pace_time),
+        AveragePaceTimeMode.entries.associateBy { it.id.toString() },
+        AveragePaceTimeMode.Active
     )
 
     override var stepHistory: Duration

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/FormatService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/FormatService.kt
@@ -534,9 +534,12 @@ class FormatService private constructor(private val context: Context) {
             .convertTo(DistanceUnits.Meters)
             .value
         val duration = Duration.ofSeconds((metersPerUnit / metersPerSecond).roundToLong())
+        val minutes = duration.toMinutes()
+        val seconds = duration.seconds % 60
+        val formattedPace = "$minutes:${seconds.toString().padStart(2, '0')}"
         return strings.getString(
             R.string.slash_separated_pair,
-            formatDuration(duration),
+            formattedPace,
             getDistanceUnitName(distanceUnit, short = true)
         )
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/FormatService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/FormatService.kt
@@ -54,6 +54,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
+import kotlin.math.roundToLong
 
 class FormatService private constructor(private val context: Context) {
 
@@ -517,6 +518,27 @@ class FormatService private constructor(private val context: Context) {
         } else {
             strings.getString(R.string.miles_per_hour_format, formattedSpeed)
         }
+    }
+
+    fun formatPace(metersPerSecond: Float): String {
+        if (!metersPerSecond.isFinite() || metersPerSecond <= 0f) {
+            return strings.getString(R.string.dash)
+        }
+
+        val distanceUnit = if (prefs.distanceUnits == UserPreferences.DistanceUnits.Meters) {
+            DistanceUnits.Kilometers
+        } else {
+            DistanceUnits.Miles
+        }
+        val metersPerUnit = Distance.from(1f, distanceUnit)
+            .convertTo(DistanceUnits.Meters)
+            .value
+        val duration = Duration.ofSeconds((metersPerUnit / metersPerSecond).roundToLong())
+        return strings.getString(
+            R.string.slash_separated_pair,
+            formatDuration(duration),
+            getDistanceUnitName(distanceUnit, short = true)
+        )
     }
 
     val builtInCoordinateFormatMap = mapOf<BuiltInCoordinateFormat, CoordinateFormat>(

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/sensors/SensorService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/sensors/SensorService.kt
@@ -142,7 +142,8 @@ class SensorService(ctx: Context) {
 
             NavigationPreferences.SpeedometerMode.AveragePace -> AveragePaceSpeedometer(
                 getAppService<StepTrackerService>(),
-                StrideLengthPaceCalculator(userPrefs.pedometer.strideLength)
+                StrideLengthPaceCalculator(userPrefs.pedometer.strideLength),
+                userPrefs.pedometer
             )
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/ActiveTimeCalculator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/ActiveTimeCalculator.kt
@@ -1,0 +1,26 @@
+package com.kylecorry.trail_sense.tools.pedometer.domain
+
+import java.time.Duration
+
+class ActiveTimeCalculator {
+
+    fun calculate(steps: Int, elapsedTime: Duration): Duration {
+        if (steps <= 0 || elapsedTime.isZero || elapsedTime.isNegative) {
+            return Duration.ZERO
+        }
+
+        val elapsedMs = elapsedTime.toMillis()
+        val stepsPerMinute = steps.toDouble() * MILLIS_PER_MINUTE / elapsedMs
+
+        return when {
+            stepsPerMinute >= MIN_ACTIVE_STEPS_PER_MINUTE -> elapsedTime
+            else -> minOf(elapsedTime, Duration.ofMillis(steps * ACTIVE_MILLIS_PER_STEP))
+        }
+    }
+
+    companion object {
+        private const val MILLIS_PER_MINUTE = 60_000L
+        private const val MIN_ACTIVE_STEPS_PER_MINUTE = 30.0
+        private const val ACTIVE_MILLIS_PER_STEP = 2_000L
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/AveragePaceTimeMode.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/AveragePaceTimeMode.kt
@@ -1,0 +1,8 @@
+package com.kylecorry.trail_sense.tools.pedometer.domain
+
+import com.kylecorry.trail_sense.shared.data.Identifiable
+
+enum class AveragePaceTimeMode(override val id: Long) : Identifiable {
+    Active(1),
+    Elapsed(2)
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/IStepTrackerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/IStepTrackerService.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
 import com.kylecorry.trail_sense.main.persistence.ICleanable
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -17,7 +18,11 @@ interface IStepTrackerService : ICleanable {
 
     suspend fun startNewStepTrackingPeriod(endTime: Instant = Instant.now())
 
-    suspend fun addSteps(steps: Long, time: Instant = Instant.now())
+    suspend fun addSteps(
+        steps: Long,
+        time: Instant = Instant.now(),
+        activeTime: Duration = Duration.ZERO
+    )
 
     suspend fun deleteStepTrackingPeriod(period: StepTrackingPeriod)
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepCountBucket.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepCountBucket.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
 import com.kylecorry.trail_sense.shared.data.Identifiable
+import java.time.Duration
 import java.time.Instant
 
 data class StepCountBucket(
@@ -8,5 +9,6 @@ data class StepCountBucket(
     val periodId: Long,
     val startTime: Instant,
     val endTime: Instant,
-    val steps: Long
+    val steps: Long,
+    val activeTime: Duration = Duration.ZERO
 ) : Identifiable

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerService.kt
@@ -90,7 +90,11 @@ class StepTrackerService(
         }
     }
 
-    override suspend fun addSteps(steps: Long, time: Instant) = stepMutex.withLock {
+    override suspend fun addSteps(
+        steps: Long,
+        time: Instant,
+        activeTime: Duration
+    ) = stepMutex.withLock {
         val existingOpenPeriod = getOrCreateOpenStepTrackingPeriodWithoutLock(time)
         val openPeriod = if (time.isBefore(existingOpenPeriod.startTime)) {
             existingOpenPeriod.copy(startTime = time).also {
@@ -103,7 +107,10 @@ class StepTrackerService(
             (time == it.startTime || time.isAfter(it.startTime)) && time.isBefore(it.endTime)
         }
         val bucketToAdd = if (containedBucket != null) {
-            containedBucket.copy(steps = containedBucket.steps + steps)
+            containedBucket.copy(
+                steps = containedBucket.steps + steps,
+                activeTime = containedBucket.activeTime.plus(activeTime)
+            )
         } else {
             // Buckets always start on the hour and are 1 hour long
             val startTime = time.toZonedDateTime()
@@ -117,7 +124,8 @@ class StepTrackerService(
                 periodId = openPeriod.id,
                 startTime = startTime,
                 endTime = endTime,
-                steps = steps
+                steps = steps,
+                activeTime = activeTime
             )
         }
         repository.upsertStepCountBucket(bucketToAdd)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackingPeriod.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackingPeriod.kt
@@ -1,6 +1,7 @@
 package com.kylecorry.trail_sense.tools.pedometer.domain
 
 import com.kylecorry.trail_sense.shared.data.Identifiable
+import java.time.Duration
 import java.time.Instant
 
 data class StepTrackingPeriod(
@@ -12,4 +13,21 @@ data class StepTrackingPeriod(
     val isOpen = endTime == null
     val steps: Long
         get() = stepCountBuckets.sumOf { it.steps }
+
+    val elapsedTime: Duration
+        get() = Duration.between(startTime, endTime ?: Instant.now())
+
+    val activeTime: Duration
+        get() {
+            val currentTime = Instant.now()
+            val totalActiveTime = stepCountBuckets.fold(Duration.ZERO) { total, bucket ->
+                val bucketActiveTime = if (bucket.steps > 0 && bucket.activeTime.isZero) {
+                    Duration.between(bucket.startTime, minOf(bucket.endTime, currentTime))
+                } else {
+                    bucket.activeTime
+                }
+                total.plus(bucketActiveTime)
+            }
+            return minOf(totalActiveTime, elapsedTime)
+        }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/AveragePaceSpeedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/AveragePaceSpeedometer.kt
@@ -7,8 +7,6 @@ import com.kylecorry.sol.units.Speed
 import com.kylecorry.trail_sense.shared.ZERO_SPEED
 import com.kylecorry.trail_sense.tools.pedometer.domain.IPaceCalculator
 import com.kylecorry.trail_sense.tools.pedometer.domain.IStepTrackerService
-import java.time.Duration
-import java.time.Instant
 
 class AveragePaceSpeedometer(
     private val stepTrackerService: IStepTrackerService,
@@ -20,7 +18,7 @@ class AveragePaceSpeedometer(
             reset()
             return@CoroutineTimer
         }
-        speed = paceCalculator.speed(stepPeriod.steps, Duration.between(stepPeriod.startTime, Instant.now()))
+        speed = paceCalculator.speed(stepPeriod.steps, stepPeriod.elapsedTime)
         hasValidReading = true
 
         notifyListeners()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/AveragePaceSpeedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/AveragePaceSpeedometer.kt
@@ -4,13 +4,18 @@ import com.kylecorry.andromeda.core.sensors.AbstractSensor
 import com.kylecorry.andromeda.core.sensors.ISpeedometer
 import com.kylecorry.luna.time.CoroutineTimer
 import com.kylecorry.sol.units.Speed
+import com.kylecorry.trail_sense.settings.infrastructure.IPedometerPreferences
 import com.kylecorry.trail_sense.shared.ZERO_SPEED
+import com.kylecorry.trail_sense.tools.pedometer.domain.AveragePaceTimeMode
 import com.kylecorry.trail_sense.tools.pedometer.domain.IPaceCalculator
 import com.kylecorry.trail_sense.tools.pedometer.domain.IStepTrackerService
+import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
+import java.time.Duration
 
 class AveragePaceSpeedometer(
     private val stepTrackerService: IStepTrackerService,
-    private val paceCalculator: IPaceCalculator
+    private val paceCalculator: IPaceCalculator,
+    private val pedometerPreferences: IPedometerPreferences
 ) : AbstractSensor(), ISpeedometer {
 
     private val timer = CoroutineTimer {
@@ -18,7 +23,7 @@ class AveragePaceSpeedometer(
             reset()
             return@CoroutineTimer
         }
-        speed = paceCalculator.speed(stepPeriod.steps, stepPeriod.elapsedTime)
+        speed = paceCalculator.speed(stepPeriod.steps, getDuration(stepPeriod))
         hasValidReading = true
 
         notifyListeners()
@@ -41,6 +46,13 @@ class AveragePaceSpeedometer(
     private fun reset() {
         hasValidReading = false
         speed = ZERO_SPEED
+    }
+
+    private fun getDuration(period: StepTrackingPeriod): Duration {
+        return when (pedometerPreferences.averagePaceTimeMode) {
+            AveragePaceTimeMode.Active -> period.activeTime
+            AveragePaceTimeMode.Elapsed -> period.elapsedTime
+        }
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/StepCounterService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/StepCounterService.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.SystemClock
 import com.kylecorry.andromeda.background.services.AndromedaService
 import com.kylecorry.andromeda.background.services.ForegroundInfo
 import com.kylecorry.andromeda.core.system.Intents
@@ -28,6 +29,7 @@ import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackerService
 import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
+import java.time.Duration
 
 class StepCounterService : AndromedaService() {
 
@@ -42,23 +44,30 @@ class StepCounterService : AndromedaService() {
 
     private val addStepsQueue = CoroutineQueueRunner()
 
+    private var lastSteps = -1
+    private var lastTime = -1L
+
     private val addStepsTask = BackgroundTask {
         addStepsQueue.enqueue {
             val currentSteps = pedometer.steps
-            if (lastSteps == -1) {
+            val currentTime = SystemClock.elapsedRealtime()
+
+            if (lastSteps == -1 || currentSteps < lastSteps) {
                 lastSteps = currentSteps
+                lastTime = currentTime
             }
 
             dailyResetCommand.execute()
 
             val newSteps = currentSteps - lastSteps
-            stepTrackerService.addSteps(newSteps.toLong())
+            val timeDelta = currentTime - lastTime
+            val activeTime = getActiveTime(newSteps, timeDelta)
+            stepTrackerService.addSteps(newSteps.toLong(), activeTime = activeTime)
             lastSteps = currentSteps
+            lastTime = currentTime
             distanceAlertCommand.execute()
         }
     }
-
-    private var lastSteps = -1
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val flag = super.onStartCommand(intent, flags, startId)
@@ -126,11 +135,26 @@ class StepCounterService : AndromedaService() {
         )
     }
 
+    private fun getActiveTime(steps: Int, elapsedMs: Long): Duration {
+        if (steps <= 0 || elapsedMs <= 0) {
+            return Duration.ZERO
+        }
+
+        val stepsPerMinute = steps.toDouble() * MILLIS_PER_MINUTE / elapsedMs
+
+        return when {
+            stepsPerMinute >= MIN_ACTIVE_STEPS_PER_MINUTE -> Duration.ofMillis(elapsedMs)
+            else -> Duration.ofMillis(minOf(elapsedMs, steps * ACTIVE_MILLIS_PER_STEP))
+        }
+    }
+
     companion object {
         const val CHANNEL_ID = "pedometer"
         const val NOTIFICATION_ID = 1279812
         private const val NOTIFICATION_GROUP_PEDOMETER = "trail_sense_pedometer"
-
+        private const val MILLIS_PER_MINUTE = 60_000L
+        private const val MIN_ACTIVE_STEPS_PER_MINUTE = 30.0
+        private const val ACTIVE_MILLIS_PER_STEP = 2_000L
 
         var isRunning = false
             private set

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/StepCounterService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/StepCounterService.kt
@@ -26,6 +26,7 @@ import com.kylecorry.trail_sense.shared.extensions.tryStartForegroundOrNotify
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.shared.sensors.SensorService
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
+import com.kylecorry.trail_sense.tools.pedometer.domain.ActiveTimeCalculator
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackerService
 import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
@@ -41,6 +42,7 @@ class StepCounterService : AndromedaService() {
     private val dailyResetCommand: CoroutineCommand by lazy { commandFactory.getDailyStepReset() }
     private val distanceAlertCommand: CoroutineCommand by lazy { commandFactory.getDistanceAlert() }
     private val notificationSubsystem = getAppService<NotificationSubsystem>()
+    private val activeTimeCalculator = ActiveTimeCalculator()
 
     private val addStepsQueue = CoroutineQueueRunner()
 
@@ -61,7 +63,7 @@ class StepCounterService : AndromedaService() {
 
             val newSteps = currentSteps - lastSteps
             val timeDelta = currentTime - lastTime
-            val activeTime = getActiveTime(newSteps, timeDelta)
+            val activeTime = activeTimeCalculator.calculate(newSteps, Duration.ofMillis(timeDelta))
             stepTrackerService.addSteps(newSteps.toLong(), activeTime = activeTime)
             lastSteps = currentSteps
             lastTime = currentTime
@@ -135,26 +137,10 @@ class StepCounterService : AndromedaService() {
         )
     }
 
-    private fun getActiveTime(steps: Int, elapsedMs: Long): Duration {
-        if (steps <= 0 || elapsedMs <= 0) {
-            return Duration.ZERO
-        }
-
-        val stepsPerMinute = steps.toDouble() * MILLIS_PER_MINUTE / elapsedMs
-
-        return when {
-            stepsPerMinute >= MIN_ACTIVE_STEPS_PER_MINUTE -> Duration.ofMillis(elapsedMs)
-            else -> Duration.ofMillis(minOf(elapsedMs, steps * ACTIVE_MILLIS_PER_STEP))
-        }
-    }
-
     companion object {
         const val CHANNEL_ID = "pedometer"
         const val NOTIFICATION_ID = 1279812
         private const val NOTIFICATION_GROUP_PEDOMETER = "trail_sense_pedometer"
-        private const val MILLIS_PER_MINUTE = 60_000L
-        private const val MIN_ACTIVE_STEPS_PER_MINUTE = 30.0
-        private const val ACTIVE_MILLIS_PER_STEP = 2_000L
 
         var isRunning = false
             private set

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepCountBucketEntity.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/persistence/StepCountBucketEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepCountBucket
+import java.time.Duration
 import java.time.Instant
 
 @Entity(
@@ -15,7 +16,8 @@ data class StepCountBucketEntity(
     @ColumnInfo(name = "period_id") val periodId: Long,
     @ColumnInfo(name = "start_time") val startTime: Instant,
     @ColumnInfo(name = "end_time") val endTime: Instant,
-    @ColumnInfo(name = "steps") val steps: Long
+    @ColumnInfo(name = "steps") val steps: Long,
+    @ColumnInfo(name = "active_time") val activeTime: Long
 ) {
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
@@ -27,7 +29,8 @@ data class StepCountBucketEntity(
             periodId = periodId,
             startTime = startTime,
             endTime = endTime,
-            steps = steps
+            steps = steps,
+            activeTime = Duration.ofMillis(activeTime)
         )
     }
 
@@ -37,7 +40,8 @@ data class StepCountBucketEntity(
                 periodId = bucket.periodId,
                 startTime = bucket.startTime,
                 endTime = bucket.endTime,
-                steps = bucket.steps
+                steps = bucket.steps,
+                activeTime = bucket.activeTime.toMillis()
             ).also {
                 it.id = bucket.id
             }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
@@ -308,12 +308,22 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
         } else {
             getString(R.string.dash)
         }
+        binding.pedometerAveragePace.title = if (averageSpeedometer.hasValidReading) {
+            formatService.formatPace(speed.value)
+        } else {
+            getString(R.string.dash)
+        }
     }
 
     private fun updateCurrentSpeed() {
         val speed = instantSpeedometer.speed
         binding.pedometerSpeed.title = if (instantSpeedometer.hasValidReading) {
             formatService.formatSpeed(speed.value)
+        } else {
+            getString(R.string.dash)
+        }
+        binding.pedometerPace.title = if (instantSpeedometer.hasValidReading) {
+            formatService.formatPace(speed.value)
         } else {
             getString(R.string.dash)
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
@@ -28,6 +28,7 @@ import com.kylecorry.trail_sense.shared.FeatureState
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
 import com.kylecorry.trail_sense.shared.UserPreferences
+import com.kylecorry.trail_sense.shared.debugging.isDebug
 import com.kylecorry.trail_sense.shared.permissions.alertNoActivityRecognitionPermission
 import com.kylecorry.trail_sense.shared.permissions.requestActivityRecognition
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
@@ -39,6 +40,7 @@ import com.kylecorry.trail_sense.tools.pedometer.infrastructure.AveragePaceSpeed
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.CurrentPaceSpeedometer
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.subsystem.PedometerSubsystem
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 
@@ -59,6 +61,7 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
 
     private var steps by state(0L)
     private var lastResetTime by state<Instant?>(null)
+    private var currentSession by state<StepTrackingPeriod?>(null)
     private var selectedDate by state(LocalDate.now())
     private var hourlySteps by state(emptyList<HourlyStepCount>())
     private var selectedHourlySteps by state<HourlyStepCount?>(null)
@@ -80,6 +83,7 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
         setupDistanceAlertButton()
         setupHourlyStepsDatePicker()
         setupPedometerSessionsButton()
+        binding.pedometerActiveTime.isVisible = isDebug()
 
         observe(averageSpeedometer) { onUpdate() }
 
@@ -182,6 +186,7 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
 
     private suspend fun updateSteps(data: Bundle?) {
         val trackingPeriod = stepTrackerService.getOpenStepTrackingPeriod()
+        currentSession = trackingPeriod
         steps = data?.getLong(PedometerToolRegistration.BROADCAST_PARAM_STEPS)
             ?: trackingPeriod?.steps
                     ?: 0L
@@ -277,6 +282,9 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
             false
         )
         binding.pedometerDistance.title = formattedDistance
+        binding.pedometerActiveTime.title = formatService.formatDuration(
+            currentSession?.activeTime ?: Duration.ZERO
+        )
 
         binding.currentSessionTime.isVisible = lastReset != null
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
@@ -50,7 +50,7 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
     private val stepTrackerService by lazy { getAppService<StepTrackerService>() }
     private val paceCalculator by lazy { StrideLengthPaceCalculator(prefs.pedometer.strideLength) }
     private val averageSpeedometer by lazy {
-        AveragePaceSpeedometer(stepTrackerService, paceCalculator)
+        AveragePaceSpeedometer(stepTrackerService, paceCalculator, prefs.pedometer)
     }
     private val instantSpeedometer by lazy {
         CurrentPaceSpeedometer(Pedometer(requireContext()), paceCalculator)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/FragmentToolPedometer.kt
@@ -28,7 +28,6 @@ import com.kylecorry.trail_sense.shared.FeatureState
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
 import com.kylecorry.trail_sense.shared.UserPreferences
-import com.kylecorry.trail_sense.shared.debugging.isDebug
 import com.kylecorry.trail_sense.shared.permissions.alertNoActivityRecognitionPermission
 import com.kylecorry.trail_sense.shared.permissions.requestActivityRecognition
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
@@ -83,8 +82,6 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
         setupDistanceAlertButton()
         setupHourlyStepsDatePicker()
         setupPedometerSessionsButton()
-        binding.pedometerActiveTime.isVisible = isDebug()
-
         observe(averageSpeedometer) { onUpdate() }
 
         observe(instantSpeedometer) { onUpdate() }
@@ -268,10 +265,18 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
             } else {
                 formatService.formatRelativeDate(lastReset.toLocalDate())
             }
-            binding.currentSessionTime.text = getString(
+            val sessionTime = getString(
                 R.string.dash_separated_pair,
                 dateString,
                 getString(R.string.now)
+            )
+            val activeTime = formatService.formatDuration(
+                currentSession?.activeTime ?: Duration.ZERO
+            )
+            binding.currentSessionTime.text = getString(
+                R.string.parenthesized_pair,
+                sessionTime,
+                getString(R.string.active_duration, activeTime)
             )
         }
 
@@ -282,10 +287,6 @@ class FragmentToolPedometer : BoundFragment<FragmentToolPedometerBinding>() {
             false
         )
         binding.pedometerDistance.title = formattedDistance
-        binding.pedometerActiveTime.title = formatService.formatDuration(
-            currentSession?.activeTime ?: Duration.ZERO
-        )
-
         binding.currentSessionTime.isVisible = lastReset != null
 
         binding.pedometerTitle.title.text = getString(R.string.pedometer)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
@@ -13,6 +13,7 @@ import com.kylecorry.trail_sense.shared.DistanceUtils.toRelativeDistance
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
 import com.kylecorry.trail_sense.shared.UserPreferences
+import com.kylecorry.trail_sense.tools.pedometer.domain.AveragePaceTimeMode
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
 import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
 import java.time.Instant
@@ -50,7 +51,10 @@ class PedometerSessionListItemMapper(
     }
 
     private fun getSubtitle(period: StepTrackingPeriod): String {
-        val duration = period.elapsedTime
+        val duration = when (prefs.pedometer.averagePaceTimeMode) {
+            AveragePaceTimeMode.Active -> period.activeTime
+            AveragePaceTimeMode.Elapsed -> period.elapsedTime
+        }
         val distance = paceCalculator.distance(period.steps)
             .convertTo(prefs.baseDistanceUnits)
             .toRelativeDistance()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSessionListItemMapper.kt
@@ -15,7 +15,6 @@ import com.kylecorry.trail_sense.shared.Units
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.tools.pedometer.domain.StepTrackingPeriod
 import com.kylecorry.trail_sense.tools.pedometer.domain.StrideLengthPaceCalculator
-import java.time.Duration
 import java.time.Instant
 
 class PedometerSessionListItemMapper(
@@ -51,7 +50,7 @@ class PedometerSessionListItemMapper(
     }
 
     private fun getSubtitle(period: StepTrackingPeriod): String {
-        val duration = Duration.between(period.startTime, period.endTime ?: Instant.now())
+        val duration = period.elapsedTime
         val distance = paceCalculator.distance(period.steps)
             .convertTo(prefs.baseDistanceUnits)
             .toRelativeDistance()

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/ui/PedometerSettingsFragment.kt
@@ -22,6 +22,7 @@ import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import com.kylecorry.trail_sense.shared.preferences.setupDistanceSetting
 import com.kylecorry.trail_sense.shared.preferences.setupNotificationSetting
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
+import com.kylecorry.trail_sense.tools.pedometer.domain.AveragePaceTimeMode
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.StepCounterService
 import com.kylecorry.trail_sense.tools.pedometer.infrastructure.subsystem.PedometerSubsystem
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
@@ -101,12 +102,23 @@ class PedometerSettingsFragment : AndromedaPreferenceFragment() {
         }
 
         setupStepHistorySetting()
+        setupAveragePaceTimeSetting()
 
         setupNotificationSetting(
             getString(R.string.pref_pedometer_notification_link),
             StepCounterService.CHANNEL_ID,
             getString(R.string.pedometer)
         )
+    }
+
+    private fun setupAveragePaceTimeSetting() {
+        val names = mapOf(
+            AveragePaceTimeMode.Active to getString(R.string.active_time),
+            AveragePaceTimeMode.Elapsed to getString(R.string.elapsed_time)
+        )
+        val averagePaceTime = list(R.string.pref_pedometer_average_pace_time)
+        averagePaceTime?.entries = names.values.toTypedArray()
+        averagePaceTime?.entryValues = names.keys.map { it.id.toString() }.toTypedArray()
     }
 
     private fun setupStepHistorySetting() {

--- a/app/src/main/res/layout/fragment_tool_pedometer.xml
+++ b/app/src/main/res/layout/fragment_tool_pedometer.xml
@@ -91,6 +91,17 @@
                     app:dataPointIcon="@drawable/ic_speed"
                     app:layout_columnWeight="1" />
 
+                <com.kylecorry.trail_sense.shared.views.DataPointView
+                    android:id="@+id/pedometer_active_time"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:visibility="gone"
+                    app:dataPointDescription="@string/active_time"
+                    app:dataPointIcon="@drawable/ic_tool_clock"
+                    app:layout_columnWeight="1"
+                    tools:visibility="visible" />
+
             </androidx.gridlayout.widget.GridLayout>
 
             <Button

--- a/app/src/main/res/layout/fragment_tool_pedometer.xml
+++ b/app/src/main/res/layout/fragment_tool_pedometer.xml
@@ -92,6 +92,24 @@
                     app:layout_columnWeight="1" />
 
                 <com.kylecorry.trail_sense.shared.views.DataPointView
+                    android:id="@+id/pedometer_pace"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    app:dataPointDescription="@string/current_pace"
+                    app:dataPointIcon="@drawable/ic_tool_clock"
+                    app:layout_columnWeight="1" />
+
+                <com.kylecorry.trail_sense.shared.views.DataPointView
+                    android:id="@+id/pedometer_average_pace"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    app:dataPointDescription="@string/average_pace"
+                    app:dataPointIcon="@drawable/ic_tool_clock"
+                    app:layout_columnWeight="1" />
+
+                <com.kylecorry.trail_sense.shared.views.DataPointView
                     android:id="@+id/pedometer_active_time"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_tool_pedometer.xml
+++ b/app/src/main/res/layout/fragment_tool_pedometer.xml
@@ -109,17 +109,6 @@
                     app:dataPointIcon="@drawable/ic_tool_clock"
                     app:layout_columnWeight="1" />
 
-                <com.kylecorry.trail_sense.shared.views.DataPointView
-                    android:id="@+id/pedometer_active_time"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="8dp"
-                    android:visibility="gone"
-                    app:dataPointDescription="@string/active_time"
-                    app:dataPointIcon="@drawable/ic_tool_clock"
-                    app:layout_columnWeight="1"
-                    tools:visibility="visible" />
-
             </androidx.gridlayout.widget.GridLayout>
 
             <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,6 +1108,7 @@
     <!--This is in Markdown format-->
     <string name="onboarding_explore">- Designed for hiking, backpacking, camping, and geocaching\n\n- Place beacons and navigate to them\n\n- Follow paths\n\n- Retrace your steps with backtrack\n\n- Plan what to pack\n\n- Be alerted before the sun sets\n\n- Predict the weather\n\n- Use your phone as a flashlight\n\n- And much more!</string>
     <string name="average_speed">Average speed</string>
+    <string name="average_pace">Average pace</string>
     <string name="steps">Steps</string>
     <string name="pref_pedometer_enabled" translatable="false">pref_pedometer_enabled</string>
     <string name="pref_pedometer_history_days" translatable="false">pref_pedometer_history_days</string>
@@ -1126,6 +1127,7 @@
     <string name="stride_length_stand_still">Stand still</string>
     <string name="stride_length_walk">Walk in a straight line, press stop when you are done</string>
     <string name="current_speed">Current speed</string>
+    <string name="current_pace">Current pace</string>
     <string name="current_speed_pedometer">Current speed (Pedometer)</string>
     <string name="current_speed_gps">Current speed (GPS)</string>
     <string name="average_speed_pedometer">Average speed (Pedometer)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1159,6 +1159,7 @@
     <string name="frequency">Frequency</string>
     <string name="tide_frequency_description">The number of high tides per day. Most tides are semidiurnal.</string>
     <string name="current_session">Current session</string>
+    <string name="active_time" translatable="false">Active time</string>
     <string name="history">History</string>
     <string name="no_pedometer_sessions">No sessions</string>
     <string name="permission_alarms_and_reminders">Alarms and reminders</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,6 +935,7 @@
     <string name="auto">Auto</string>
     <string name="dash_separated_pair" translatable="false">%1$s - %2$s</string>
     <string name="dot_separated_pair" translatable="false">%1$s • %2$s</string>
+    <string name="parenthesized_pair" translatable="false">%1$s (%2$s)</string>
     <string name="dot" translatable="false">•</string>
     <string name="slash_separated_pair" translatable="false">%1$s / %2$s</string>
     <string name="delete_path">Delete path?</string>
@@ -1164,6 +1165,7 @@
     <string name="tide_frequency_description">The number of high tides per day. Most tides are semidiurnal.</string>
     <string name="current_session">Current session</string>
     <string name="active_time">Active time</string>
+    <string name="active_duration">Active: %s</string>
     <string name="elapsed_time">Elapsed time</string>
     <string name="history">History</string>
     <string name="no_pedometer_sessions">No sessions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1112,6 +1112,8 @@
     <string name="pref_pedometer_enabled" translatable="false">pref_pedometer_enabled</string>
     <string name="pref_pedometer_history_days" translatable="false">pref_pedometer_history_days</string>
     <string name="pref_pedometer_history_days_title">Step history</string>
+    <string name="pref_pedometer_average_pace_time" translatable="false">pref_pedometer_average_pace_time</string>
+    <string name="pref_pedometer_average_pace_time_title">Average pace time</string>
     <string name="pref_distance_alert" translatable="false">pref_distance_alert</string>
     <string name="distance_alert">Distance alert</string>
     <string name="remove_distance_alert">Remove distance alert (%s)?</string>
@@ -1159,7 +1161,8 @@
     <string name="frequency">Frequency</string>
     <string name="tide_frequency_description">The number of high tides per day. Most tides are semidiurnal.</string>
     <string name="current_session">Current session</string>
-    <string name="active_time" translatable="false">Active time</string>
+    <string name="active_time">Active time</string>
+    <string name="elapsed_time">Elapsed time</string>
     <string name="history">History</string>
     <string name="no_pedometer_sessions">No sessions</string>
     <string name="permission_alarms_and_reminders">Alarms and reminders</string>

--- a/app/src/main/res/xml/odometer_calibration.xml
+++ b/app/src/main/res/xml/odometer_calibration.xml
@@ -51,6 +51,14 @@
             app:key="@string/pref_pedometer_history_days"
             app:singleLineTitle="false" />
 
+        <ListPreference
+            android:defaultValue="1"
+            android:title="@string/pref_pedometer_average_pace_time_title"
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_pedometer_average_pace_time"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:summary="@string/alarm_description"

--- a/app/src/test/java/com/kylecorry/trail_sense/settings/migrations/PedometerPreferenceMigrationTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/settings/migrations/PedometerPreferenceMigrationTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -136,7 +137,7 @@ internal class PedometerPreferenceMigrationTest {
         override suspend fun startNewStepTrackingPeriod(endTime: Instant) {
         }
 
-        override suspend fun addSteps(steps: Long, time: Instant) {
+        override suspend fun addSteps(steps: Long, time: Instant, activeTime: Duration) {
             addedSteps.add(StepAddition(steps, time))
         }
 

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/ActiveTimeCalculatorTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/ActiveTimeCalculatorTest.kt
@@ -1,0 +1,34 @@
+package com.kylecorry.trail_sense.tools.pedometer.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+import java.util.stream.Stream
+
+internal class ActiveTimeCalculatorTest {
+
+    private val calculator = ActiveTimeCalculator()
+
+    @ParameterizedTest
+    @MethodSource("provideActiveTimes")
+    fun calculate(steps: Int, elapsedTime: Duration, expected: Duration) {
+        assertEquals(expected, calculator.calculate(steps, elapsedTime))
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideActiveTimes(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(0, Duration.ofSeconds(10), Duration.ZERO),
+                Arguments.of(-1, Duration.ofSeconds(10), Duration.ZERO),
+                Arguments.of(10, Duration.ZERO, Duration.ZERO),
+                Arguments.of(10, Duration.ofSeconds(-1), Duration.ZERO),
+                Arguments.of(10, Duration.ofSeconds(10), Duration.ofSeconds(10)),
+                Arguments.of(10, Duration.ofMinutes(1), Duration.ofSeconds(20)),
+                Arguments.of(10, Duration.ofSeconds(15), Duration.ofSeconds(15))
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerServiceTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackerServiceTest.kt
@@ -207,14 +207,39 @@ internal class StepTrackerServiceTest {
     fun addStepsAddsToExistingBucketWhenTimeIsInsideBucket() = runBlocking {
         val startTime = Instant.parse("2026-01-01T10:00:00Z")
         val openPeriod = repository.addPeriod(period(id = 1, startTime = startTime))
-        repository.addBucket(bucket(id = 2, periodId = openPeriod.id, startTime = startTime, steps = 10))
+        repository.addBucket(
+            bucket(
+                id = 2,
+                periodId = openPeriod.id,
+                startTime = startTime,
+                steps = 10,
+                activeTime = Duration.ofSeconds(1)
+            )
+        )
 
-        service.addSteps(7, Instant.parse("2026-01-01T10:59:59Z"))
+        service.addSteps(
+            7,
+            Instant.parse("2026-01-01T10:59:59Z"),
+            activeTime = Duration.ofSeconds(2)
+        )
 
         assertEquals(17, service.getOpenStepTrackingPeriod()?.steps)
         assertEquals(1, repository.buckets.size)
         assertEquals(17, repository.buckets.first().steps)
+        assertEquals(Duration.ofSeconds(3), repository.buckets.first().activeTime)
         verifyStepsChanged(17)
+    }
+
+    @Test
+    fun addStepsSavesActiveTimeToNewBucket() = runBlocking {
+        val time = Instant.parse("2026-01-01T10:15:30Z")
+
+        service.addSteps(12, time, activeTime = Duration.ofSeconds(5))
+
+        assertEquals(
+            Duration.ofSeconds(5),
+            service.getOpenStepTrackingPeriod()?.stepCountBuckets?.single()?.activeTime
+        )
     }
 
     @Test
@@ -377,9 +402,10 @@ internal class StepTrackerServiceTest {
         periodId: Long,
         startTime: Instant = Instant.parse("2026-01-01T10:00:00Z"),
         endTime: Instant = startTime.plusSeconds(3600),
-        steps: Long = 1
+        steps: Long = 1,
+        activeTime: Duration = Duration.ZERO
     ): StepCountBucket {
-        return StepCountBucket(id, periodId, startTime, endTime, steps)
+        return StepCountBucket(id, periodId, startTime, endTime, steps, activeTime)
     }
 
     private class FakeStepTrackerRepository : IStepTrackerRepository {

--- a/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackingPeriodTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/tools/pedometer/domain/StepTrackingPeriodTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.time.Instant
 
 internal class StepTrackingPeriodTest {
@@ -38,6 +39,91 @@ internal class StepTrackingPeriodTest {
         assertEquals(350L, period.steps)
     }
 
+    @Test
+    fun elapsedTimeIsTimeBetweenStartAndEnd() {
+        val period = period(
+            startTime = Instant.parse("2026-01-01T10:00:00Z"),
+            endTime = Instant.parse("2026-01-01T11:30:00Z")
+        )
+
+        assertEquals(Duration.ofMinutes(90), period.elapsedTime)
+    }
+
+    @Test
+    fun activeTimeIsTheSumOfBucketActiveTimes() {
+        val period = period(
+            endTime = Instant.parse("2026-01-01T01:00:00Z"),
+            stepCountBuckets = listOf(
+                bucket(id = 1, steps = 100, activeTime = Duration.ofMinutes(10)),
+                bucket(id = 2, steps = 200, activeTime = Duration.ofMinutes(15))
+            )
+        )
+
+        assertEquals(Duration.ofMinutes(25), period.activeTime)
+    }
+
+    @Test
+    fun activeTimeUsesBucketDurationWhenBucketHasStepsAndNoActiveTime() {
+        val period = period(
+            endTime = Instant.parse("2026-01-01T01:00:00Z"),
+            stepCountBuckets = listOf(
+                bucket(
+                    steps = 100,
+                    startTime = Instant.parse("2026-01-01T00:10:00Z"),
+                    endTime = Instant.parse("2026-01-01T00:40:00Z")
+                )
+            )
+        )
+
+        assertEquals(Duration.ofMinutes(30), period.activeTime)
+    }
+
+    @Test
+    fun activeTimeDoesNotUseBucketDurationWhenBucketHasNoSteps() {
+        val period = period(
+            endTime = Instant.parse("2026-01-01T01:00:00Z"),
+            stepCountBuckets = listOf(bucket(steps = 0))
+        )
+
+        assertEquals(Duration.ZERO, period.activeTime)
+    }
+
+    @Test
+    fun activeTimeCapsFallbackBucketEndTimeToCurrentTime() {
+        val currentTime = Instant.now()
+        val period = period(
+            startTime = currentTime.minus(Duration.ofHours(1)),
+            endTime = currentTime.plus(Duration.ofHours(1)),
+            stepCountBuckets = listOf(
+                bucket(
+                    steps = 100,
+                    startTime = currentTime.minus(Duration.ofMinutes(30)),
+                    endTime = currentTime.plus(Duration.ofMinutes(30))
+                )
+            )
+        )
+
+        assertTrue(period.activeTime >= Duration.ofMinutes(30))
+        assertTrue(period.activeTime < Duration.ofMinutes(31))
+    }
+
+    @Test
+    fun activeTimeIsCappedToElapsedTime() {
+        val period = period(
+            startTime = Instant.parse("2026-01-01T00:15:00Z"),
+            endTime = Instant.parse("2026-01-01T00:45:00Z"),
+            stepCountBuckets = listOf(
+                bucket(
+                    steps = 100,
+                    startTime = Instant.parse("2026-01-01T00:00:00Z"),
+                    endTime = Instant.parse("2026-01-01T01:00:00Z")
+                )
+            )
+        )
+
+        assertEquals(Duration.ofMinutes(30), period.activeTime)
+    }
+
     private fun period(
         id: Long = 1,
         startTime: Instant = Instant.parse("2026-01-01T00:00:00Z"),
@@ -52,8 +138,9 @@ internal class StepTrackingPeriodTest {
         periodId: Long = 1,
         startTime: Instant = Instant.parse("2026-01-01T00:00:00Z"),
         endTime: Instant = Instant.parse("2026-01-01T00:01:00Z"),
-        steps: Long = 0
+        steps: Long = 0,
+        activeTime: Duration = Duration.ZERO
     ): StepCountBucket {
-        return StepCountBucket(id, periodId, startTime, endTime, steps)
+        return StepCountBucket(id, periodId, startTime, endTime, steps, activeTime)
     }
 }

--- a/guides/en-US/guide_tool_pedometer.txt
+++ b/guides/en-US/guide_tool_pedometer.txt
@@ -3,7 +3,7 @@ The Pedometer tool can be used to track the distance traveled by counting your s
 ## Track distance and speed
 To track the distance traveled, tap the start button in the bottom-right corner of the screen. You may be asked to grant the "Physical Activity" permission, which allows Trail Sense to access your phone's pedometer. You can then put your phone away and begin your hike.
 
-The distance traveled will be shown at the top of the screen, along with the number of steps taken, your average speed, and your current speed. The average speed is calculated since the last reset, and does not factor in breaks. The current speed is calculated over the last 10 seconds. The distance traveled is calculated based on your steps and stride length. The time since the last reset is shown at the top of the screen.
+The distance traveled will be shown at the top of the screen, along with the number of steps taken, your average speed, and your current speed. By default, the average speed uses active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time. The current speed is calculated over the last 10 seconds. The distance traveled is calculated based on your steps and stride length. The time since the last reset is shown at the top of the screen.
 
 You can stop the pedometer at any point (e.g., while resting or at a campsite) by clicking the stop button in the bottom-right corner. Stopping the pedometer will not reset the distance traveled, so you can resume it by clicking start again. If you want to start a new measurement, you can click the reset button instead.
 

--- a/guides/en-US/guide_tool_pedometer.txt
+++ b/guides/en-US/guide_tool_pedometer.txt
@@ -7,6 +7,8 @@ The distance traveled and number of steps taken are shown at the top of the scre
 
 Your current and average speed and pace are also shown. Pace is displayed as time per kilometer or mile, depending on your distance units. The current speed and pace are calculated over the last 10 seconds. By default, the average speed and pace use active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time.
 
+If you are not familiar with pace, a pace of 12:30 / km means it takes 12 minutes and 30 seconds to travel one kilometer. A lower pace means you are moving faster.
+
 The current session time is shown at the top of the screen, followed by the active duration in parentheses.
 
 You can stop the pedometer at any point (e.g., while resting or at a campsite) by clicking the stop button in the bottom-right corner. Stopping the pedometer will not reset the distance traveled, so you can resume it by clicking start again. If you want to start a new measurement, you can click the reset button instead.

--- a/guides/en-US/guide_tool_pedometer.txt
+++ b/guides/en-US/guide_tool_pedometer.txt
@@ -3,7 +3,11 @@ The Pedometer tool can be used to track the distance traveled by counting your s
 ## Track distance, speed, and pace
 To track the distance traveled, tap the start button in the bottom-right corner of the screen. You may be asked to grant the "Physical Activity" permission, which allows Trail Sense to access your phone's pedometer. You can then put your phone away and begin your hike.
 
-The distance traveled will be shown at the top of the screen, along with the number of steps taken, your average speed and pace, and current speed and pace. Pace is shown as time per kilometer or mile, depending on your distance units. By default, the average speed and pace use active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time. The current speed and pace are calculated over the last 10 seconds. The distance traveled is calculated based on your steps and stride length. The time since the last reset is shown at the top of the screen.
+The distance traveled and number of steps taken are shown at the top of the screen. The distance is calculated based on your steps and stride length.
+
+Your current and average speed and pace are also shown. Pace is displayed as time per kilometer or mile, depending on your distance units. The current speed and pace are calculated over the last 10 seconds. By default, the average speed and pace use active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time.
+
+The current session time is shown at the top of the screen, followed by the active duration in parentheses.
 
 You can stop the pedometer at any point (e.g., while resting or at a campsite) by clicking the stop button in the bottom-right corner. Stopping the pedometer will not reset the distance traveled, so you can resume it by clicking start again. If you want to start a new measurement, you can click the reset button instead.
 

--- a/guides/en-US/guide_tool_pedometer.txt
+++ b/guides/en-US/guide_tool_pedometer.txt
@@ -1,9 +1,9 @@
 The Pedometer tool can be used to track the distance traveled by counting your steps.
 
-## Track distance and speed
+## Track distance, speed, and pace
 To track the distance traveled, tap the start button in the bottom-right corner of the screen. You may be asked to grant the "Physical Activity" permission, which allows Trail Sense to access your phone's pedometer. You can then put your phone away and begin your hike.
 
-The distance traveled will be shown at the top of the screen, along with the number of steps taken, your average speed, and your current speed. By default, the average speed uses active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time. The current speed is calculated over the last 10 seconds. The distance traveled is calculated based on your steps and stride length. The time since the last reset is shown at the top of the screen.
+The distance traveled will be shown at the top of the screen, along with the number of steps taken, your average speed and pace, and current speed and pace. Pace is shown as time per kilometer or mile, depending on your distance units. By default, the average speed and pace use active time since the last reset, which does not include breaks. You can include breaks by selecting elapsed time under Settings > Pedometer > Average pace time. The current speed and pace are calculated over the last 10 seconds. The distance traveled is calculated based on your steps and stride length. The time since the last reset is shown at the top of the screen.
 
 You can stop the pedometer at any point (e.g., while resting or at a campsite) by clicking the stop button in the bottom-right corner. Stopping the pedometer will not reset the distance traveled, so you can resume it by clicking start again. If you want to start a new measurement, you can click the reset button instead.
 


### PR DESCRIPTION
Adds the tracking of "active time", which is time when the user is actively walking. This allows for better average speed calculations since breaks can be ignored. Uses a baseline of 30 steps/minute for it to be considered active, and up to 2 seconds per step when inactive (to avoid having steps with no active time). The active time is displayed on the pedometer tool and users can switch between active (default) and elapsed time for the average speed calculation. Also adds the pace (current, average) per mile or kilometer for better estimation of hiking times.

For migration purposes, if a step count bucket has steps without an active time then it defaults to the current behavior of using elapsed time. This means the ongoing pedometer session will remain somewhat inactive, but I suspect most users have it auto-resetting daily or are explicitly starting and stopping the pedometer so it won't be inaccurate forever.

Issue: #3890
