### PR TITLE
fix(battery): show unknown Wi-Fi/Bluetooth status when airplane mode affects detection

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
@@ -53,8 +53,8 @@ class BatteryService {
 
     fun getSystemBatteryTips(context: Context): List<SystemBatteryTip> {
         val isAirplaneOn = tryOrDefault(false) { SystemSettings.isAirplaneModeEnabled(context) }
-        val isWifiOn = tryOrDefault(true) { SystemSettings.isWifiEnabled(context) }
-        val isBluetoothOn = tryOrDefault(true) { SystemSettings.isBluetoothEnabled(context) }
+        val isWifiOn = tryOrDefault(null) { SystemSettings.isWifiEnabled(context) }
+        val isBluetoothOn = tryOrDefault(null) { SystemSettings.isBluetoothEnabled(context) }
         val isNfcOn = tryOrDefault(true) { SystemSettings.isNfcEnabled(context) }
         val isPowerSaverOn = tryOrDefault(false) { SystemSettings.isPowerSaverEnabled(context) }
         val isLocationOn = tryOrDefault(true) { SystemSettings.isLocationEnabled(context) }
@@ -73,8 +73,16 @@ class BatteryService {
             ),
             SystemBatteryTip(
                 context.getString(R.string.wifi),
-                if (!isWifiOn) context.getString(R.string.off) else context.getString(R.string.battery_tip_wifi),
-                if (isWifiOn) BatteryUsage.High else BatteryUsage.Low,
+                when (isWifiOn) {
+                    true -> context.getString(R.string.battery_tip_wifi)
+                    false -> context.getString(R.string.off)
+                    null -> context.getString(R.string.unknown)
+                },
+                when (isWifiOn) {
+                    true -> BatteryUsage.High
+                    false -> BatteryUsage.Low
+                    null -> BatteryUsage.Unknown
+                },
                 getSystemAction(
                     context, if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         Settings.Panel.ACTION_WIFI
@@ -85,8 +93,16 @@ class BatteryService {
             ),
             SystemBatteryTip(
                 context.getString(R.string.bluetooth),
-                if (!isBluetoothOn) context.getString(R.string.off) else context.getString(R.string.battery_tip_bluetooth),
-                if (isBluetoothOn) BatteryUsage.High else BatteryUsage.Low,
+                when (isBluetoothOn) {
+                    true -> context.getString(R.string.battery_tip_bluetooth)
+                    false -> context.getString(R.string.off)
+                    null -> context.getString(R.string.unknown)
+                },
+                when (isBluetoothOn) {
+                    true -> BatteryUsage.High
+                    false -> BatteryUsage.Low
+                    null -> BatteryUsage.Unknown
+                },
                 getSystemAction(context, Settings.ACTION_BLUETOOTH_SETTINGS)
             ),
             SystemBatteryTip(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/BatteryService.kt
@@ -51,6 +51,7 @@ class BatteryService {
         return powerService.getTimeUntilFull(capacity, maxCapacity, lastChargeRate)
     }
 
+    @Suppress("LongMethod")
     fun getSystemBatteryTips(context: Context): List<SystemBatteryTip> {
         val isAirplaneOn = tryOrDefault(false) { SystemSettings.isAirplaneModeEnabled(context) }
         val isWifiOn = tryOrDefault(null) { SystemSettings.isWifiEnabled(context) }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/SystemSettings.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/battery/infrastructure/SystemSettings.kt
@@ -25,24 +25,28 @@ object SystemSettings {
         )?.split(',') ?: emptyList()
     }
 
-    fun isWifiEnabled(context: Context): Boolean {
+    fun isWifiEnabled(context: Context): Boolean? {
         if (!getBooleanSystemSetting(context, Settings.Global.WIFI_ON)) {
             return false
         }
         if (!isAirplaneModeEnabled(context)) {
             return true
         }
-        return !getAirplaneModeRadios(context).contains(Settings.Global.RADIO_WIFI)
+        // Airplane mode is on but Wi-Fi was re-enabled; the raw setting may be
+        // stale and cannot be trusted without ACCESS_WIFI_STATE permission.
+        return null
     }
 
-    fun isBluetoothEnabled(context: Context): Boolean {
+    fun isBluetoothEnabled(context: Context): Boolean? {
         if (!getBooleanSystemSetting(context, Settings.Global.BLUETOOTH_ON)) {
             return false
         }
         if (!isAirplaneModeEnabled(context)) {
             return true
         }
-        return !getAirplaneModeRadios(context).contains(Settings.Global.RADIO_BLUETOOTH)
+        // Airplane mode is on but Bluetooth was re-enabled; the raw setting may be
+        // stale and cannot be trusted without BLUETOOTH_CONNECT permission.
+        return null
     }
 
     fun isNfcEnabled(context: Context): Boolean {


### PR DESCRIPTION
## Fixes #3896

### Description
Fixes an issue where Battery usage incorrectly showed Wi-Fi and Bluetooth as **Off** when airplane mode was enabled and the user manually re-enabled Wi-Fi or Bluetooth.

Android can return unreliable `Settings.Global` values in this state unless additional permissions are available (`ACCESS_WIFI_STATE` / `BLUETOOTH_CONNECT`). Previously, Trail Sense could incorrectly report these features as disabled.

### Changes Made

- Updated `SystemSettings.isWifiEnabled()` to return `Boolean?`
  - Returns `null` when airplane mode is enabled and the Wi-Fi state cannot be reliably determined.
- Updated `SystemSettings.isBluetoothEnabled()` to return `Boolean?`
  - Returns `null` when airplane mode is enabled and Bluetooth state may be inaccurate.
- Updated `BatteryService` to handle unknown states:
  - `true` → Enabled
  - `false` → Disabled
  - `null` → `BatteryUsage.Unknown`

When the state is unknown, Battery usage now displays **"Unknown"** with the existing gray help icon instead of incorrectly showing **"Off"**.

### Why This Is Needed

Airplane mode changes the reliability of Android's reported Wi-Fi/Bluetooth state. Reporting a definite "Off" status can be misleading when the system cannot verify the actual state.

This change avoids false information while keeping the existing UI behavior for unknown battery usage states.

### Testing

Tested manually with:
- Airplane mode disabled → Wi-Fi/Bluetooth states report normally
- Airplane mode enabled → Wi-Fi/Bluetooth status becomes unknown when state cannot be verified
- Battery usage screen displays "Unknown" correctly

### Screenshots

<img width="1600" height="896" alt="Screenshot_2026-07-16_15-45-47" src="https://github.com/user-attachments/assets/aa02640c-39aa-4025-a90a-7c518e3caa6e" />
