### PR TITLE
navigation: increase location font size

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/views/Toolbar.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/views/Toolbar.kt
@@ -2,7 +2,10 @@ package com.kylecorry.trail_sense.shared.views
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
@@ -15,6 +18,7 @@ class Toolbar(context: Context, attrs: AttributeSet?) : FrameLayout(context, att
     val rightButton: MaterialButton
     val title: TextView
     val subtitle: TextView
+    private val textContainer: LinearLayout
 
     init {
         inflate(context, R.layout.view_toolbar, this)
@@ -22,6 +26,7 @@ class Toolbar(context: Context, attrs: AttributeSet?) : FrameLayout(context, att
         rightButton = findViewById(R.id.toolbar_right_button)
         title = findViewById(R.id.toolbar_title)
         subtitle = findViewById(R.id.toolbar_subtitle)
+        textContainer = findViewById(R.id.toolbar_text_container)
 
         val a = context.theme.obtainStyledAttributes(attrs, R.styleable.Toolbar, 0, 0)
         title.text = a.getString(R.styleable.Toolbar_title) ?: ""
@@ -50,6 +55,36 @@ class Toolbar(context: Context, attrs: AttributeSet?) : FrameLayout(context, att
         }
 
         a.recycle()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+        val actionSpace = maxOf(
+            getActionSpace(leftButton),
+            getActionSpace(rightButton)
+        )
+        if (textContainer.paddingStart != actionSpace ||
+            textContainer.paddingEnd != actionSpace
+        ) {
+            textContainer.setPaddingRelative(
+                actionSpace,
+                textContainer.paddingTop,
+                actionSpace,
+                textContainer.paddingBottom
+            )
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        }
+    }
+
+    private fun getActionSpace(button: View): Int {
+        if (!button.isVisible) {
+            return 0
+        }
+
+        val margins = button.layoutParams as? MarginLayoutParams
+        return button.measuredWidth + (margins?.marginStart ?: 0) +
+                (margins?.marginEnd ?: 0)
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/LocationBottomSheet.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/LocationBottomSheet.kt
@@ -39,6 +39,7 @@ class LocationBottomSheet : BoundBottomSheetDialogFragment<FragmentLocationBindi
 
         format = prefs.navigation.coordinateFormat
 
+        binding.locationTitle.title.textSize = 32f
         binding.locationTitle.subtitle.setCompoundDrawables(
             Resources.dp(requireContext(), 24f).toInt(),
             right = R.drawable.ic_drop_down

--- a/app/src/main/res/layout/view_toolbar.xml
+++ b/app/src/main/res/layout/view_toolbar.xml
@@ -7,13 +7,13 @@
     android:padding="16dp">
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/toolbar_right_button"
+        app:layout_constraintStart_toEndOf="@id/toolbar_left_button"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView

--- a/app/src/main/res/layout/view_toolbar.xml
+++ b/app/src/main/res/layout/view_toolbar.xml
@@ -7,13 +7,14 @@
     android:padding="16dp">
 
     <LinearLayout
+        android:id="@+id/toolbar_text_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/toolbar_right_button"
-        app:layout_constraintStart_toEndOf="@id/toolbar_left_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView


### PR DESCRIPTION
Increases the coordinate text size on the location sheet to 32sp, making it easier to read aloud when reporting a location in an emergency. Coordinate formatting and the rest of the sheet are unchanged.

![Trail Sense location sheet showing the larger 32sp coordinate](https://gist.githubusercontent.com/arpitagarwal1301/27216cd5295b17f607376d265080399b/raw/3f24f7250ed8f697d13489f484eb8ad48b0690a7/trail-sense-location-2738.png)

Issue: #2738

## Checklist

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
