### PR TITLE
Fix alarm audio on Android 17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -174,6 +174,12 @@
         </service>
 
         <service
+            android:name=".shared.alerts.AlarmService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
+        <service
             android:name="com.kylecorry.trail_sense.tools.paths.infrastructure.services.BacktrackService"
             android:enabled="true"
             android:exported="false"

--- a/app/src/main/java/com/kylecorry/trail_sense/main/NotificationChannels.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/main/NotificationChannels.kt
@@ -2,6 +2,8 @@ package com.kylecorry.trail_sense.main
 
 import android.content.Context
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.shared.alerts.AlarmService
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 
 object NotificationChannels {
@@ -11,6 +13,16 @@ object NotificationChannels {
     private const val CHANNEL_BACKGROUND_LAUNCHER = "background_launcher"
 
     fun createChannels(context: Context) {
+        Notify.createChannel(
+            context,
+            AlarmService.NOTIFICATION_CHANNEL_ID,
+            context.getString(R.string.permission_alarms_and_reminders),
+            context.getString(R.string.alarm_description),
+            Notify.CHANNEL_IMPORTANCE_LOW,
+            muteSound = true,
+            showBadge = false
+        )
+
         val tools = Tools.getTools(context)
         val channels = tools.flatMap { it.notificationChannels }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmAlerter.kt
@@ -1,89 +1,28 @@
 package com.kylecorry.trail_sense.shared.alerts
 
 import android.content.Context
-import android.media.MediaPlayer
-import android.net.Uri
-import com.kylecorry.andromeda.core.cache.DependencyRegistry
-import com.kylecorry.luna.time.CoroutineTimer
-import com.kylecorry.andromeda.notify.Notify
-import com.kylecorry.andromeda.sound.SystemSoundPlayer
-import com.kylecorry.trail_sense.shared.haptics.HapticSubsystem
-import com.kylecorry.trail_sense.shared.io.FileSubsystem
-import java.time.Duration
+import android.os.Build
+import com.kylecorry.andromeda.permissions.Permissions
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 
 class AlarmAlerter(
     private val context: Context,
     private val isEnabled: Boolean,
-    private val notificationChannel: String
+    private val notificationChannel: String,
+    private val isInForeground: Boolean = false
 ) :
     IAlerter {
 
-    private val systemPlayer = SystemSoundPlayer(context)
-    private val files = DependencyRegistry.get<FileSubsystem>()
-
     override fun alert() {
-        if (!isEnabled) {
+        val hasPermission = isInForeground || Permissions.canPlayAlarmInBackground(context)
+        if (!isEnabled || !hasPermission) {
             return
         }
 
-        val player = getPlayer() ?: return
-
-        val haptics = HapticSubsystem.getInstance(context)
-
-        val duration = player.duration
-
-        val timer = CoroutineTimer {
-            player.stop()
-        }
-
-        val end = if (duration == -1) {
-            Duration.ofSeconds(5)
+        if (!isInForeground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+            AlarmService.start(context, notificationChannel)
         } else {
-            Duration.ofMillis(duration.toLong()).coerceAtMost(Duration.ofSeconds(5))
+            AlarmPlayer(context, notificationChannel).play()
         }
-
-        timer.once(end)
-
-        player.start()
-        haptics.alert()
-        player.isLooping = false
-    }
-
-    private fun getPlayer(): MediaPlayer? {
-        val options = listOf(
-            Pair(getUri(), SystemSoundPlayer.AudioChannel.Alarm),
-            Pair(systemPlayer.getNotificationUri(), SystemSoundPlayer.AudioChannel.Alarm),
-            Pair(getUri(), SystemSoundPlayer.AudioChannel.Notification),
-            Pair(systemPlayer.getNotificationUri(), SystemSoundPlayer.AudioChannel.Notification),
-        )
-
-        for (option in options) {
-            val player = tryGetPlayer(option.first ?: continue, option.second)
-            if (player != null) {
-                return player
-            }
-        }
-        return null
-    }
-
-    private fun tryGetPlayer(uri: Uri, channel: SystemSoundPlayer.AudioChannel): MediaPlayer? {
-        try {
-            return systemPlayer.player(
-                uri,
-                channel
-            )
-        } catch (_: Exception) {
-            // Do nothing
-        }
-        return null
-    }
-
-    private fun getUri(): Uri? {
-        val channelUri = Notify.getSoundUri(context, notificationChannel)
-        if (channelUri != null && files.canRead(channelUri)) {
-            return channelUri
-        }
-
-        return systemPlayer.getNotificationUri()
     }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmPlayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmPlayer.kt
@@ -1,0 +1,82 @@
+package com.kylecorry.trail_sense.shared.alerts
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.net.Uri
+import com.kylecorry.andromeda.core.cache.DependencyRegistry
+import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.sound.SystemSoundPlayer
+import com.kylecorry.luna.time.CoroutineTimer
+import com.kylecorry.trail_sense.shared.haptics.HapticSubsystem
+import com.kylecorry.trail_sense.shared.io.FileSubsystem
+import java.time.Duration
+
+internal class AlarmPlayer(
+    private val context: Context,
+    private val notificationChannel: String,
+    private val onComplete: () -> Unit = {}
+) {
+    private val systemPlayer = SystemSoundPlayer(context)
+    private val files = DependencyRegistry.get<FileSubsystem>()
+
+    fun play() {
+        val player = getPlayer()
+        if (player == null) {
+            onComplete()
+            return
+        }
+        val haptics = HapticSubsystem.getInstance(context)
+        val duration = player.duration
+        val timer = CoroutineTimer {
+            try {
+                player.stop()
+            } finally {
+                onComplete()
+            }
+        }
+        val end = if (duration == -1) {
+            Duration.ofSeconds(5)
+        } else {
+            Duration.ofMillis(duration.toLong()).coerceAtMost(Duration.ofSeconds(5))
+        }
+
+        timer.once(end)
+        player.start()
+        haptics.alert()
+        player.isLooping = false
+    }
+
+    private fun getPlayer(): MediaPlayer? {
+        val options = listOf(
+            Pair(getUri(), SystemSoundPlayer.AudioChannel.Alarm),
+            Pair(systemPlayer.getNotificationUri(), SystemSoundPlayer.AudioChannel.Alarm),
+            Pair(getUri(), SystemSoundPlayer.AudioChannel.Notification),
+            Pair(systemPlayer.getNotificationUri(), SystemSoundPlayer.AudioChannel.Notification),
+        )
+
+        for (option in options) {
+            val player = tryGetPlayer(option.first ?: continue, option.second)
+            if (player != null) {
+                return player
+            }
+        }
+        return null
+    }
+
+    private fun tryGetPlayer(uri: Uri, channel: SystemSoundPlayer.AudioChannel): MediaPlayer? {
+        try {
+            return systemPlayer.player(uri, channel)
+        } catch (_: Exception) {
+            // Do nothing
+        }
+        return null
+    }
+
+    private fun getUri(): Uri? {
+        val channelUri = Notify.getSoundUri(context, notificationChannel)
+        if (channelUri != null && files.canRead(channelUri)) {
+            return channelUri
+        }
+        return systemPlayer.getNotificationUri()
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmService.kt
@@ -1,0 +1,58 @@
+package com.kylecorry.trail_sense.shared.alerts
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import androidx.core.content.ContextCompat
+import com.kylecorry.andromeda.background.services.AndromedaService
+import com.kylecorry.andromeda.background.services.ForegroundInfo
+import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.trail_sense.R
+import java.time.Duration
+
+class AlarmService : AndromedaService() {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val notificationChannel = intent?.getStringExtra(EXTRA_NOTIFICATION_CHANNEL)
+        if (notificationChannel == null) {
+            stopService(true)
+            return START_NOT_STICKY
+        }
+
+        acquireWakelock("AlarmService", Duration.ofMillis(WAKE_LOCK_TIMEOUT_MS))
+
+        AlarmPlayer(this, notificationChannel) { stopService(true) }.play()
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        stopService(true)
+        super.onDestroy()
+    }
+
+    override fun getForegroundInfo() = ForegroundInfo(
+        NOTIFICATION_ID,
+        Notify.background(
+            this,
+            NOTIFICATION_CHANNEL_ID,
+            getString(R.string.alarm_notification_title),
+            null,
+            R.drawable.ic_alert
+        ),
+        listOf(ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+    )
+
+    companion object {
+        private const val EXTRA_NOTIFICATION_CHANNEL = "notification_channel"
+        private const val WAKE_LOCK_TIMEOUT_MS = 7000L
+        private const val NOTIFICATION_ID = 2390424
+        const val NOTIFICATION_CHANNEL_ID = "alarm_service"
+
+        fun start(context: Context, notificationChannel: String) {
+            val intent = Intent(context, AlarmService::class.java).apply {
+                putExtra(EXTRA_NOTIFICATION_CHANNEL, notificationChannel)
+            }
+            ContextCompat.startForegroundService(context, intent)
+        }
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/permissions/PermissionUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/permissions/PermissionUtils.kt
@@ -136,6 +136,13 @@ fun Permissions.canGetLocationCustom(context: Context): Boolean {
     return isBackgroundLocationEnabled(context) || canGetLocation(context, checkAppOps = true)
 }
 
+fun Permissions.canPlayAlarmInBackground(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) {
+        return true
+    }
+    return hasPermission(context, SpecialPermission.SCHEDULE_EXACT_ALARMS)
+}
+
 /**
  * Request location permission when absolutely required to start a foreground service (Android 14+)
  */

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunriseAlarmCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunriseAlarmCommand.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.sol.math.Range
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
@@ -14,6 +15,7 @@ import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.commands.CoroutineCommand
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.sensors.LocationSubsystem
 import com.kylecorry.trail_sense.tools.astronomy.AstronomyToolRegistration
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
@@ -119,7 +121,7 @@ class SunriseAlarmCommand(private val context: Context) : CoroutineCommand {
             R.drawable.ic_sunrise_notification,
             intent = openIntent,
             autoCancel = true,
-            mute = useAlarm
+            mute = useAlarm && Permissions.canPlayAlarmInBackground(context)
         )
 
         DependencyRegistry.get<NotificationSubsystem>().send(NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunsetAlarmCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunsetAlarmCommand.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.sol.math.Range
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
@@ -14,6 +15,7 @@ import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.commands.CoroutineCommand
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.sensors.LocationSubsystem
 import com.kylecorry.trail_sense.tools.astronomy.AstronomyToolRegistration
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
@@ -116,7 +118,7 @@ class SunsetAlarmCommand(private val context: Context) : CoroutineCommand {
             R.drawable.ic_sunset_notification,
             intent = openIntent,
             autoCancel = true,
-            mute = useAlarm
+            mute = useAlarm && Permissions.canPlayAlarmInBackground(context)
         )
 
         DependencyRegistry.get<NotificationSubsystem>().send(NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/DistanceAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/DistanceAlerter.kt
@@ -51,7 +51,9 @@ class DistanceAlerter(private val context: Context) : IAlerter {
         val alarm = AlarmAlerter(
             context,
             useAlarm,
-            PedometerToolRegistration.NOTIFICATION_CHANNEL_DISTANCE_ALERT
+            PedometerToolRegistration.NOTIFICATION_CHANNEL_DISTANCE_ALERT,
+            // This is always called from a foreground service
+            isInForeground = true
         )
         alarm.alert()
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/turn_back/infrastructure/receivers/TurnBackAlarmReceiver.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/turn_back/infrastructure/receivers/TurnBackAlarmReceiver.kt
@@ -9,12 +9,14 @@ import com.kylecorry.andromeda.background.OneTimeTaskSchedulerFactory
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.fragments.IPermissionRequester
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.permissions.requestScheduleExactAlarms
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import com.kylecorry.trail_sense.tools.turn_back.TurnBackToolRegistration
 import com.kylecorry.trail_sense.tools.turn_back.ui.TurnBackFragment
@@ -41,7 +43,7 @@ class TurnBackAlarmReceiver : BroadcastReceiver() {
             R.drawable.ic_undo,
             group = NOTIFIATION_GROUP,
             autoCancel = true,
-            mute = useAlarm
+            mute = useAlarm && Permissions.canPlayAlarmInBackground(context)
         )
         DependencyRegistry.get<NotificationSubsystem>().send(
             TURN_BACK_NOTIFICATION_ID,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/waterpurification/infrastructure/WaterPurificationTimerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/waterpurification/infrastructure/WaterPurificationTimerService.kt
@@ -68,7 +68,9 @@ class WaterPurificationTimerService : AndromedaService() {
             val alarm = AlarmAlerter(
                 this,
                 useAlarm,
-                WaterBoilTimerToolRegistration.NOTIFICATION_CHANNEL_WATER_BOIL_TIMER
+                WaterBoilTimerToolRegistration.NOTIFICATION_CHANNEL_WATER_BOIL_TIMER,
+                // This is always called from a foreground service
+                isInForeground = true
             )
             alarm.alert()
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/weather/infrastructure/alerts/StormAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/weather/infrastructure/alerts/StormAlerter.kt
@@ -3,12 +3,14 @@ package com.kylecorry.trail_sense.tools.weather.infrastructure.alerts
 import android.content.Context
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.IDismissibleAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.tools.weather.WeatherToolRegistration
 
 class StormAlerter(private val context: Context) : IDismissibleAlerter {
@@ -25,7 +27,7 @@ class StormAlerter(private val context: Context) : IDismissibleAlerter {
             group = NOTIFICATION_GROUP_STORM,
             intent = NavigationUtils.pendingIntent(context, R.id.action_weather),
             autoCancel = true,
-            mute = useAlarm
+            mute = useAlarm && Permissions.canPlayAlarmInBackground(context)
         )
         DependencyRegistry.get<NotificationSubsystem>()
             .send(STORM_ALERT_NOTIFICATION_ID, notification)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1797,6 +1797,7 @@
     <string name="use_alarm_for_sunset_alert">Use alarm for sunset alert</string>
     <string name="use_alarm_for_sunrise_alert">Use alarm for sunrise alert</string>
     <string name="alarm_description">Plays a sound even if media and notifications are muted</string>
+    <string name="alarm_notification_title">Alarm in progress</string>
     <string name="mute_alarm_at_night">Mute alarm at night</string>
     <!--Start to end time (ex. 8AM to 8PM)-->
     <string name="alarm_time_range">Only plays from %1$s to %2$s</string>


### PR DESCRIPTION
Android 17 requires a FGS of type mediaPlayback w/ exact alarm in order to  play the alarm audio. The previous approach is now blocked so no sound or vibration is played. https://developer.android.com/about/versions/17/changes/bg-audio

Trail Sense already has the mediaPlayback permission allowed by Google Play, so there shouldn't be any issues there. It looks like some other apps with alarms use this approach as well.

Setting notification channel's audio usage to USAGE_ALARM did not work.

Issue: #3901