### PR TITLE
Check permission before using alarm audio on Android 17

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/alerts/AlarmAlerter.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.media.MediaPlayer
 import android.net.Uri
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
-import com.kylecorry.luna.time.CoroutineTimer
 import com.kylecorry.andromeda.notify.Notify
 import com.kylecorry.andromeda.sound.SystemSoundPlayer
+import com.kylecorry.luna.time.CoroutineTimer
 import com.kylecorry.trail_sense.shared.haptics.HapticSubsystem
 import com.kylecorry.trail_sense.shared.io.FileSubsystem
 import java.time.Duration
@@ -14,7 +14,8 @@ import java.time.Duration
 class AlarmAlerter(
     private val context: Context,
     private val isEnabled: Boolean,
-    private val notificationChannel: String
+    private val notificationChannel: String,
+    private val onComplete: () -> Unit = {}
 ) :
     IAlerter {
 
@@ -34,6 +35,7 @@ class AlarmAlerter(
 
         val timer = CoroutineTimer {
             player.stop()
+            onComplete()
         }
 
         val end = if (duration == -1) {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/permissions/PermissionUtils.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/permissions/PermissionUtils.kt
@@ -8,6 +8,7 @@ import com.kylecorry.andromeda.alerts.Alerts
 import com.kylecorry.andromeda.alerts.toast
 import com.kylecorry.andromeda.camera.Camera
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
+import com.kylecorry.andromeda.core.system.CurrentApp
 import com.kylecorry.andromeda.fragments.AndromedaFragment
 import com.kylecorry.andromeda.fragments.IPermissionRequester
 import com.kylecorry.andromeda.markdown.MarkdownService
@@ -134,6 +135,39 @@ fun Permissions.canStartLocationForgroundService(context: Context): Boolean {
 
 fun Permissions.canGetLocationCustom(context: Context): Boolean {
     return isBackgroundLocationEnabled(context) || canGetLocation(context, checkAppOps = true)
+}
+
+fun Permissions.canPlayAlarmInBackground(
+    context: Context,
+    hasWhileInUsePermissionOverride: Boolean? = null
+): Boolean {
+    // https://developer.android.com/about/versions/17/changes/bg-audio
+    // Android 17+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) {
+        return true
+    }
+
+    // Must have a visible activity or must be running a foreground service that is not of type SHORT_SERVICE (not used by Trail Sense)
+    val isActivityOpen = CurrentApp.isInForeground(includeForegroundServices = false)
+    if (isActivityOpen) {
+        return true
+    }
+
+    val hasForegroundService = CurrentApp.isInForeground(includeForegroundServices = true)
+
+    /**
+     *  If the app is running in the background, the app must be running a foreground service that has while-in-use (WIU) capabilities.
+     *
+     *  However, the requirement for WIU capabilities is waived if the app has been granted the exact alarm permission,
+     *  and it is making changes to audio streams that have the USAGE_ALARM attribute.
+     *
+     *  NOTE: There doesn't seem to be a way to check if the FGS has while-in-use capabilities
+     */
+    val meetsWhileInUseCriteria =
+        hasWhileInUsePermissionOverride == true || hasPermission(context, SpecialPermission.SCHEDULE_EXACT_ALARMS)
+
+
+    return hasForegroundService && meetsWhileInUseCriteria
 }
 
 /**

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunriseAlarmCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunriseAlarmCommand.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.sol.math.Range
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
@@ -14,6 +15,7 @@ import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.commands.CoroutineCommand
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.sensors.LocationSubsystem
 import com.kylecorry.trail_sense.tools.astronomy.AstronomyToolRegistration
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
@@ -107,7 +109,7 @@ class SunriseAlarmCommand(private val context: Context) : CoroutineCommand {
 
         val openIntent = NavigationUtils.pendingIntent(context, R.id.action_astronomy)
 
-        val useAlarm = userPrefs.astronomy.useAlarmForSunriseAlert
+        val useAlarm = userPrefs.astronomy.useAlarmForSunriseAlert && Permissions.canPlayAlarmInBackground(context)
         val notification = Notify.alert(
             context,
             NOTIFICATION_CHANNEL_ID,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunsetAlarmCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/infrastructure/commands/SunsetAlarmCommand.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.sol.math.Range
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
@@ -14,6 +15,7 @@ import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.commands.CoroutineCommand
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.sensors.LocationSubsystem
 import com.kylecorry.trail_sense.tools.astronomy.AstronomyToolRegistration
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
@@ -104,7 +106,7 @@ class SunsetAlarmCommand(private val context: Context) : CoroutineCommand {
 
         val openIntent = NavigationUtils.pendingIntent(context, R.id.action_astronomy)
 
-        val useAlarm = userPrefs.astronomy.useAlarmForSunsetAlert
+        val useAlarm = userPrefs.astronomy.useAlarmForSunsetAlert && Permissions.canPlayAlarmInBackground(context)
         val notification = Notify.alert(
             context,
             NOTIFICATION_CHANNEL_ID,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/DistanceAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/pedometer/infrastructure/DistanceAlerter.kt
@@ -3,6 +3,7 @@ package com.kylecorry.trail_sense.tools.pedometer.infrastructure
 import android.content.Context
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.Units
@@ -11,6 +12,7 @@ import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.IAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.toRelativeDistance
 import com.kylecorry.trail_sense.tools.pedometer.PedometerToolRegistration
 
@@ -25,7 +27,7 @@ class DistanceAlerter(private val context: Context) : IAlerter {
         val distance =
             prefs.pedometer.alertDistance?.convertTo(prefs.baseDistanceUnits)?.toRelativeDistance()
 
-        val useAlarm = prefs.pedometer.useAlarmForDistanceAlert
+        val useAlarm = prefs.pedometer.useAlarmForDistanceAlert && Permissions.canPlayAlarmInBackground(context)
         val notification = Notify.alert(
             context,
             NOTIFICATION_CHANNEL_ID,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/turn_back/infrastructure/receivers/TurnBackAlarmReceiver.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/turn_back/infrastructure/receivers/TurnBackAlarmReceiver.kt
@@ -9,11 +9,13 @@ import com.kylecorry.andromeda.background.OneTimeTaskSchedulerFactory
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.fragments.IPermissionRequester
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.permissions.requestScheduleExactAlarms
 import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import com.kylecorry.trail_sense.tools.turn_back.TurnBackToolRegistration
@@ -32,7 +34,7 @@ class TurnBackAlarmReceiver : BroadcastReceiver() {
         val formattedReturnTime =
             FormatService.getInstance(context).formatTime(returnTime, includeSeconds = false)
 
-        val useAlarm = userPrefs.turnBack.useAlarm
+        val useAlarm = userPrefs.turnBack.useAlarm && Permissions.canPlayAlarmInBackground(context)
         val notification = Notify.alert(
             context,
             NOTIFICATION_CHANNEL_ID,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/waterpurification/infrastructure/WaterPurificationTimerService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/waterpurification/infrastructure/WaterPurificationTimerService.kt
@@ -9,11 +9,14 @@ import com.kylecorry.andromeda.background.services.ForegroundInfo
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.core.system.Intents
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
+import com.kylecorry.luna.time.CoroutineTimer
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.shared.safeRoundToInt
 import com.kylecorry.trail_sense.tools.waterpurification.WaterBoilTimerToolRegistration
 
@@ -50,27 +53,6 @@ class WaterPurificationTimerService : AndromedaService() {
         timer?.cancel()
         if (!done) {
             Notify.cancel(this, NOTIFICATION_ID)
-        } else {
-            val prefs = DependencyRegistry.get<UserPreferences>()
-            val useAlarm = prefs.waterBoilTimer.useAlarm
-            val notification = Notify.alert(
-                this@WaterPurificationTimerService,
-                CHANNEL_ID,
-                getString(R.string.water_boil_timer_done_title),
-                getString(R.string.water_boil_timer_done_content),
-                R.drawable.ic_tool_boil_done,
-                group = NOTIFICATION_GROUP_WATER,
-                intent = openIntent,
-                mute = useAlarm
-            )
-            DependencyRegistry.get<NotificationSubsystem>().send(NOTIFICATION_ID, notification)
-
-            val alarm = AlarmAlerter(
-                this,
-                useAlarm,
-                WaterBoilTimerToolRegistration.NOTIFICATION_CHANNEL_WATER_BOIL_TIMER
-            )
-            alarm.alert()
         }
         stopService(false)
         super.onDestroy()
@@ -94,10 +76,38 @@ class WaterPurificationTimerService : AndromedaService() {
 
             override fun onFinish() {
                 done = true
-                stopService(false)
+                alertTimerComplete()
             }
 
         }.start()
+    }
+
+    private fun alertTimerComplete() {
+        val prefs = DependencyRegistry.get<UserPreferences>()
+        val useAlarm = prefs.waterBoilTimer.useAlarm && Permissions.canPlayAlarmInBackground(
+            this,
+            // This FGS was started by the user, there's no other way to start it so it has while-in-use permission
+            hasWhileInUsePermissionOverride = true
+        )
+        val notification = Notify.alert(
+            this,
+            CHANNEL_ID,
+            getString(R.string.water_boil_timer_done_title),
+            getString(R.string.water_boil_timer_done_content),
+            R.drawable.ic_tool_boil_done,
+            group = NOTIFICATION_GROUP_WATER,
+            intent = openIntent,
+            mute = useAlarm
+        )
+        DependencyRegistry.get<NotificationSubsystem>().send(NOTIFICATION_ID, notification)
+
+        val alarm = AlarmAlerter(
+            this,
+            useAlarm,
+            WaterBoilTimerToolRegistration.NOTIFICATION_CHANNEL_WATER_BOIL_TIMER,
+            onComplete = { stopService(false) }
+        )
+        alarm.alert()
     }
 
     private fun getNotification(secondsLeft: Int): Notification {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/weather/infrastructure/alerts/StormAlerter.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/weather/infrastructure/alerts/StormAlerter.kt
@@ -3,19 +3,21 @@ package com.kylecorry.trail_sense.tools.weather.infrastructure.alerts
 import android.content.Context
 import com.kylecorry.andromeda.core.cache.DependencyRegistry
 import com.kylecorry.andromeda.notify.Notify
+import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.alerts.AlarmAlerter
 import com.kylecorry.trail_sense.shared.alerts.IDismissibleAlerter
 import com.kylecorry.trail_sense.shared.alerts.NotificationSubsystem
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
+import com.kylecorry.trail_sense.shared.permissions.canPlayAlarmInBackground
 import com.kylecorry.trail_sense.tools.weather.WeatherToolRegistration
 
 class StormAlerter(private val context: Context) : IDismissibleAlerter {
 
     override fun alert() {
         val prefs = DependencyRegistry.get<UserPreferences>()
-        val useAlarm = prefs.weather.useAlarmForStormAlert
+        val useAlarm = prefs.weather.useAlarmForStormAlert && Permissions.canPlayAlarmInBackground(context)
         val notification = Notify.alert(
             context,
             STORM_CHANNEL_ID,


### PR DESCRIPTION
See https://developer.android.com/about/versions/17/changes/bg-audio for the background audio changes. This is a temporary fix to at least have it use the appropriate notification sounds on Android 17 when use alarms is true.

It requires that the app is either in the foreground or has a FGS AND is granted exact alarms permission. The only exception is the water boil timer which is running in a while-in-use FGS. The other FGS can be started in the background on boot, so they don't get a pass. The storm alert might be fine because I believe location always gets while-in-use, but it is hard to tell from the docs.

I believe the actual solution may involve starting a FGS for the alarm for the alerts.

The water boil timer was updated to add a delay before stopping the FGS to avoid android misclassifying it as not in the foreground.

Issue: #3901