### PR TITLE
astronomy: Show correct moon tilt

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/AstronomyService.kt
@@ -124,7 +124,7 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
         location: Coordinate,
         time: ZonedDateTime = ZonedDateTime.now(),
         useNearestTransit: Boolean = false
-    ): Float {
+    ): MoonTilt {
         val timeToUse = if (useNearestTransit) {
             getMoonTimes(location, time.toLocalDate()).transit ?: getMoonTimes(
                 location,
@@ -134,8 +134,9 @@ class AstronomyService(private val clock: Clock = Clock.systemDefaultZone()) {
             time
         }
 
-
-        return Astronomy.getMoonParallacticAngle(timeToUse, location)
+        val parallacticAngle = Astronomy.getMoonParallacticAngle(timeToUse, location)
+        val brightLimbAngleFromNorth = Astronomy.getMoonPositionAngleOfBrightLimb(timeToUse)
+        return MoonTilt(parallacticAngle, brightLimbAngleFromNorth)
     }
 
     // PUBLIC SUN METHODS

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/MoonDetails.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/MoonDetails.kt
@@ -14,5 +14,5 @@ data class MoonDetails(
     val illumination: Float,
     val altitude: Float,
     val azimuth: Bearing,
-    val tilt: Float
+    val tilt: MoonTilt
 )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/MoonTilt.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/domain/MoonTilt.kt
@@ -1,0 +1,6 @@
+package com.kylecorry.trail_sense.tools.astronomy.domain
+
+data class MoonTilt(
+    val parallacticAngle: Float,
+    val brightLimbAngleFromNorth: Float
+)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstroChart.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstroChart.kt
@@ -20,6 +20,7 @@ import com.kylecorry.trail_sense.shared.andromeda_temp.ClickChartLayer
 import com.kylecorry.trail_sense.shared.colors.ColorUtils
 import com.kylecorry.trail_sense.shared.views.chart.label.HourChartLabelFormatter
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomyService
+import com.kylecorry.trail_sense.tools.astronomy.domain.MoonTilt
 import com.kylecorry.trail_sense.tools.navigation.ui.BitmapLoader
 import java.time.Instant
 import java.time.ZonedDateTime
@@ -236,13 +237,12 @@ class AstroChart(
         chart.invalidate()
     }
 
-    fun moveMoon(position: Reading<Float>?, tilt: Float? = null) {
+    fun moveMoon(position: Reading<Float>?) {
         moonImage.data = if (position == null) {
             emptyList()
         } else {
             Chart.getDataFromReadings(listOf(position), startTime) { it }
         }
-        moonImage.rotation = tilt ?: 0f
         updateMoonArea()
         chart.invalidate()
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/AstronomyFragment.kt
@@ -16,6 +16,7 @@ import com.kylecorry.andromeda.fragments.inBackground
 import com.kylecorry.andromeda.markdown.MarkdownService
 import com.kylecorry.andromeda.pickers.Pickers
 import com.kylecorry.andromeda.sense.location.IGPS
+import com.kylecorry.luna.concurrency.CoroutineQueueRunner
 import com.kylecorry.luna.concurrency.onDefault
 import com.kylecorry.luna.concurrency.onMain
 import com.kylecorry.luna.text.capitalizeWords
@@ -59,6 +60,7 @@ import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
@@ -90,7 +92,8 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
     private var location by state(Coordinate.zero)
     private var currentSeekChartTime by state(ZonedDateTime.now())
     private var isSeeking by state(false)
-    private var currentMoonTilt by state(0f)
+
+    private val moonUpdaterQueue = CoroutineQueueRunner()
 
     private val astroChartDataProvider by lazy {
         if (prefs.astronomy.centerSunAndMoon) {
@@ -353,17 +356,16 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
             return
         }
 
-        val displayDate = binding.displayDate.date
-
-        val moonPhase = withContext(Dispatchers.Default) {
-            if (displayDate == LocalDate.now()) {
-                astronomyService.getCurrentMoonPhase()
-            } else {
-                astronomyService.getMoonPhase(displayDate)
-            }
+        val time = if (isSeeking) {
+            currentSeekChartTime
+        } else if (displayDate == LocalDate.now()) {
+            ZonedDateTime.now()
+        } else {
+            displayDate.atStartOfDay(ZoneId.systemDefault())
         }
 
-        currentMoonTilt = onDefault { astronomyService.getMoonTilt(location) }
+        val moonPhase = onDefault { astronomyService.getMoonPhase(time) }
+        val tilt = onDefault { astronomyService.getMoonTilt(location, time) }
 
         withContext(Dispatchers.Main) {
             val size = Resources.dp(requireContext(), 24f).toInt()
@@ -371,7 +373,8 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
                 MoonPhaseImageMapper(requireContext()).getPhaseImage(
                     moonPhase.phaseAngle,
                     size,
-                    size
+                    size,
+                    tilt
                 )
             )
         }
@@ -416,13 +419,12 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
     private fun plotMoonImage(
         altitudes: List<Reading<Float>>,
         time: ZonedDateTime = ZonedDateTime.now(),
-        tilt: Float? = null
     ) {
         val instant = time.toInstant()
         val current = altitudes.minByOrNull {
             Duration.between(instant, it.time).abs()
         }
-        chart.moveMoon(current, tilt ?: currentMoonTilt)
+        chart.moveMoon(current)
     }
 
     private suspend fun updateAstronomyDetails() {
@@ -548,7 +550,6 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
             currentSeekChartTime,
             isSeeking,
             location,
-            currentMoonTilt,
             triggers.frequency("chart", Duration.ofMinutes(1)),
             lifecycleHookTrigger.onResume()
         ) {
@@ -558,10 +559,8 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
                 }
                 updateAstronomyChart()
 
-                val tilt = astronomyService.getMoonTilt(location, currentSeekChartTime)
-
                 if (isSeeking) {
-                    plotMoonImage(data.moon, currentSeekChartTime, tilt)
+                    plotMoonImage(data.moon, currentSeekChartTime)
                     plotSunImage(data.sun, currentSeekChartTime)
                 }
             }
@@ -581,11 +580,15 @@ class AstronomyFragment : BoundFragment<ActivityAstronomyBinding>() {
         effect(
             "moon_phase",
             displayDate,
+            currentSeekChartTime,
+            isSeeking,
             triggers.frequency("moon_phase", Duration.ofMinutes(15)),
             lifecycleHookTrigger.onResume()
         ) {
             inBackground {
-                updateMoonUI()
+                moonUpdaterQueue.enqueue {
+                    updateMoonUI()
+                }
             }
         }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/LunarEclipseImageMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/LunarEclipseImageMapper.kt
@@ -11,6 +11,7 @@ import com.kylecorry.sol.math.trigonometry.Trigonometry
 import com.kylecorry.sol.science.astronomy.eclipse.LunarEclipseShadow
 import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.tools.astronomy.domain.MoonTilt
 
 class LunarEclipseImageMapper(private val context: Context) {
 
@@ -23,14 +24,14 @@ class LunarEclipseImageMapper(private val context: Context) {
         shadow: LunarEclipseShadow,
         width: Int,
         height: Int,
-        tilt: Float? = null
+        tilt: MoonTilt? = null
     ): Bitmap {
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
         val drawer = CanvasDrawer(context, canvas)
         drawer.push()
         tilt?.let {
-            drawer.rotate(it, width / 2f, height / 2f)
+            drawer.rotate(it.parallacticAngle, width / 2f, height / 2f)
         }
         moonDrawable?.let {
             it.setBounds(0, 0, width, height)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/MoonPhaseImageMapper.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/MoonPhaseImageMapper.kt
@@ -14,6 +14,7 @@ import com.kylecorry.andromeda.core.system.Resources
 import com.kylecorry.sol.math.arithmetic.Arithmetic
 import com.kylecorry.sol.math.trigonometry.Trigonometry.cosDegrees
 import com.kylecorry.trail_sense.R
+import com.kylecorry.trail_sense.tools.astronomy.domain.MoonTilt
 import kotlin.math.abs
 
 class MoonPhaseImageMapper(private val context: Context) {
@@ -30,19 +31,27 @@ class MoonPhaseImageMapper(private val context: Context) {
         phaseAngle: Float,
         width: Int,
         height: Int,
-        tilt: Float? = null
+        tilt: MoonTilt? = null
     ): Bitmap {
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
         canvas.withSave {
             tilt?.let {
-                rotate(it, width / 2f, height / 2f)
+                rotate(it.parallacticAngle, width / 2f, height / 2f)
             }
             moonDrawable?.let {
                 it.setBounds(0, 0, width, height)
                 it.draw(this)
             }
 
+            tilt?.let {
+                val rotationAdjustment = if (phaseAngle < 180) {
+                    90f
+                } else {
+                    -90f
+                }
+                rotate(-(it.brightLimbAngleFromNorth + rotationAdjustment), width / 2f, height / 2f)
+            }
             drawShadow(this, phaseAngle, width.toFloat(), height.toFloat(), shadowPaint)
         }
         return output

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/LunarEclipseListItemProducer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/ui/items/LunarEclipseListItemProducer.kt
@@ -11,6 +11,7 @@ import com.kylecorry.sol.science.astronomy.units.CelestialObservation
 import com.kylecorry.sol.units.Coordinate
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.declination.DeclinationUtils
+import com.kylecorry.trail_sense.tools.astronomy.domain.MoonTilt
 import com.kylecorry.trail_sense.tools.astronomy.ui.LunarEclipseImageMapper
 import com.kylecorry.trail_sense.tools.astronomy.ui.format.EclipseFormatter
 import java.time.LocalDate
@@ -84,7 +85,7 @@ class LunarEclipseListItemProducer(context: Context) : BaseAstroListItemProducer
     private fun getIcon(
         moon: CelestialObservation,
         shadow: LunarEclipseShadow,
-        moonTilt: Float
+        moonTilt: MoonTilt
     ): DrawableListIcon {
         return DrawableListIcon(
             LunarEclipseImageMapper(context).getEclipseImage(

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/widgets/SunAndMoonChartToolWidgetView.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/astronomy/widgets/SunAndMoonChartToolWidgetView.kt
@@ -3,10 +3,9 @@ package com.kylecorry.trail_sense.tools.astronomy.widgets
 import android.content.Context
 import android.view.View
 import android.widget.RemoteViews
-import com.kylecorry.andromeda.views.chart.Chart
 import com.kylecorry.andromeda.core.system.Resources
+import com.kylecorry.andromeda.views.chart.Chart
 import com.kylecorry.luna.concurrency.onMain
-import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.navigation.NavigationUtils
 import com.kylecorry.trail_sense.tools.astronomy.domain.AstronomySubsystem
@@ -48,11 +47,11 @@ class SunAndMoonChartToolWidgetView : ChartToolWidgetViewBase() {
 
             val size = Resources.dp(context, 24f).toInt()
             val moonImage =
-                MoonPhaseImageMapper(context).getPhaseImage(moon.phaseAngle, size, size)
+                MoonPhaseImageMapper(context).getPhaseImage(moon.phaseAngle, size, size, moon.tilt)
 
             astroChart.setMoonImage(moonImage)
             astroChart.moveSun(currentSun)
-            astroChart.moveMoon(currentMoon, moon.tilt)
+            astroChart.moveMoon(currentMoon)
 
             renderChart(context, views, chart)
         }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/data/NavAstronomyData.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/data/NavAstronomyData.kt
@@ -1,10 +1,12 @@
 package com.kylecorry.trail_sense.tools.navigation.ui.data
 
+import com.kylecorry.trail_sense.tools.astronomy.domain.MoonTilt
+
 data class NavAstronomyData(
     val sunBearing: Float,
     val moonBearing: Float,
     val isSunUp: Boolean,
     val isMoonUp: Boolean,
     val moonPhaseAngle: Float,
-    val moonTilt: Float
+    val moonTilt: MoonTilt
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ mockitoKotlin = "6.3.0"
 mapsforge = "2d514f37cd"
 orion = "1.1.0"
 roomVersion = "2.8.4"
-sol = "19.0.3"
+sol = "19.1.0"
 workRuntimeKtx = "2.11.2"
 preferenceKtx = "1.2.1"
 


### PR DESCRIPTION
Previously it was just using parallactic angle, but now it factors in both parallactic angle and the bright limb angle.

It intentionally rotates by the parallactic angle first and then rotates again when drawing the shadow. This is because the position angle is relative to the North Pole rather than zenith so it doesn't need an additional rotation.

Tested in multiple places around the world against online sources and it seems to line up better than before.

Updates sol which exposed the position angle.

Issue: #3851