### PR TITLE
Fix: Selecting a precipitation month discards the selected year

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/climate/ui/ClimateFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/climate/ui/ClimateFragment.kt
@@ -28,6 +28,7 @@ import com.kylecorry.trail_sense.shared.views.ElevationInputView
 import com.kylecorry.trail_sense.tools.climate.domain.BiologicalActivityType
 import com.kylecorry.trail_sense.tools.climate.domain.PhenologyService
 import com.kylecorry.trail_sense.tools.weather.infrastructure.subsystem.WeatherSubsystem
+import com.kylecorry.luna.hooks.Ref
 import java.time.LocalDate
 import java.time.Month
 
@@ -73,6 +74,11 @@ class ClimateFragment : TrailSenseReactiveFragment(R.layout.fragment_tool_climat
         val (date, setDate) = useState(LocalDate.now())
         val (location, setLocation) = useState(locationSubsystem.location)
         val (elevation, setElevation) = useState(locationSubsystem.elevation.convertTo(distanceUnits))
+        val dateRef = useRef(date)
+
+        useEffect(date) {
+            dateRef.current = date
+        }
 
         // Charts
         val temperatureChart = useMemo(temperatureChartView) {
@@ -83,8 +89,7 @@ class ClimateFragment : TrailSenseReactiveFragment(R.layout.fragment_tool_climat
 
         val precipitationChart = useMemo(precipitationChartView) {
             MonthlyPrecipitationChart(precipitationChartView) {
-                // TODO: This really needs the prev version of a setter
-                setDate(LocalDate.now().withDayOfMonth(15).withMonth(it.value))
+                setDate(dateRef.current.withDayOfMonth(15).withMonth(it.value))
             }
         }
 


### PR DESCRIPTION
Selecting a precipitation bar on the climate tool was resetting the date
to the current year regardless of what year the user had selected. For
example, selecting a date in 2024 and tapping a precipitation bar would
jump to that month in 2026, causing temperature and ecology data to reload
for the wrong year.

The root cause was a stale closure in the `useMemo(precipitationChartView)`
block. Because `useMemo` only re-runs when its dependencies change (and
`precipitationChartView` never changes), the lambda captured `date` at
creation time and never saw updated values.

The fix uses `useRef` to hold a reference to the current date that is kept
in sync via `useEffect(date)`. The precipitation chart lambda reads
`dateRef.current` instead, which always reflects the latest selected date.
This matches how the temperature chart already behaves (it receives a full
`LocalDate` directly from the chart callback).

Screenshots:
<img width="1600" height="896" alt="Screenshot_2026-07-26_01-20-20" src="https://github.com/user-attachments/assets/3f9fd6ff-b98d-44e8-9df0-1e8591b381d3" />
<img width="1600" height="896" alt="Screenshot_2026-07-26_01-20-28" src="https://github.com/user-attachments/assets/fe30beea-4a71-4fd6-ba87-79fff13bb4f2" />


Issue: #3932

## Checklist

- [x] I have tested these changes on an Android device or emulator