### PR TITLE
fix: show error toast when packing list export is canceled or fails

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/packs/ui/commands/ExportPackingListCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/packs/ui/commands/ExportPackingListCommand.kt
@@ -25,8 +25,12 @@ class ExportPackingListCommand(private val fragment: AndromedaFragment) : Comman
             Alerts.withLoading(fragment.requireContext(), fragment.getString(R.string.loading)) {
                 items = repo.getItemsFromPackAsync(value.id)
             }
-            exportService.export(items, "${value.name.slugify()}.csv")
-            fragment.toast(fragment.getString(R.string.exported))
+            val exported = exportService.export(items, "${value.name.slugify()}.csv")
+            if (exported) {
+                fragment.toast(fragment.getString(R.string.exported))
+            } else {
+                fragment.toast(fragment.getString(R.string.export_failed))
+            }
         }
     }
 }


### PR DESCRIPTION
`ExportPackingListCommand` was discarding the `Boolean` returned by
`exportService.export()` and unconditionally showing "Exported" — even
when the user canceled the file picker or the write failed.

Now checks the return value and shows "Unable to export" (`R.string.export_failed`)
on failure, and "Exported" only on success.

Issue: #3942

## Checklist
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator