### PR TITLE
Fix: Canceling photo map deletion no longer closes the viewer

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/commands/DeleteMapCommand.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/commands/DeleteMapCommand.kt
@@ -4,15 +4,14 @@ import android.content.Context
 import com.kylecorry.andromeda.alerts.CoroutineAlerts
 import com.kylecorry.luna.concurrency.onMain
 import com.kylecorry.trail_sense.R
-import com.kylecorry.trail_sense.shared.commands.generic.CoroutineCommand
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapCatalogItem
 import com.kylecorry.trail_sense.tools.offline_maps.domain.OfflineMapService
 
 class DeleteMapCommand(
     private val context: Context,
     private val mapService: OfflineMapService
-) : CoroutineCommand<OfflineMapCatalogItem> {
-    override suspend fun execute(value: OfflineMapCatalogItem) {
+) {
+    suspend fun execute(value: OfflineMapCatalogItem): Boolean {
         val shouldDelete = onMain {
             !CoroutineAlerts.dialog(
                 context,
@@ -25,9 +24,10 @@ class DeleteMapCommand(
         }
 
         if (!shouldDelete) {
-            return
+            return false
         }
 
         mapService.delete(value)
+        return true
     }
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/PhotoMapsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/offline_maps/ui/photo_maps/PhotoMapsFragment.kt
@@ -141,8 +141,10 @@ class PhotoMapsFragment : BoundFragment<FragmentToolPhotoMapsBinding>() {
     private fun delete() {
         inBackground {
             map?.let {
-                DeleteMapCommand(requireContext(), service).execute(it)
-                findNavController().popBackStack()
+                val deleted = DeleteMapCommand(requireContext(), service).execute(it)
+                if (deleted) {
+                    findNavController().popBackStack()
+                }
             }
         }
     }


### PR DESCRIPTION
`DeleteMapCommand` was returning normally (no signal) when the user canceled the confirmation dialog.
`PhotoMapsFragment.delete()` was unconditionally calling `popBackStack()` after executing the command,
so canceling the dialog still dismissed the viewer.

Fixed by removing the `CoroutineCommand` interface from `DeleteMapCommand` and changing `execute` to
return `Boolean` — `true` if the map was deleted, `false` if the user canceled. `PhotoMapsFragment`
now only calls `popBackStack()` when `true` is returned.

Closes: #3941

## Checklist
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator