### PR TITLE
Fix stale sleep timer UI after white noise timer expires naturally

### DIFF
--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/whitenoise/ToolWhiteNoiseTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/whitenoise/ToolWhiteNoiseTest.kt
@@ -7,6 +7,8 @@ import com.kylecorry.trail_sense.test_utils.AutomationLibrary.clickOk
 import com.kylecorry.trail_sense.test_utils.AutomationLibrary.hasText
 import com.kylecorry.trail_sense.test_utils.AutomationLibrary.input
 import com.kylecorry.trail_sense.test_utils.AutomationLibrary.isFalse
+import com.kylecorry.trail_sense.test_utils.AutomationLibrary.isNotChecked
+import com.kylecorry.trail_sense.test_utils.AutomationLibrary.isNotVisible
 import com.kylecorry.trail_sense.test_utils.AutomationLibrary.isTrue
 import com.kylecorry.trail_sense.test_utils.AutomationLibrary.not
 import com.kylecorry.trail_sense.test_utils.TestUtils
@@ -17,7 +19,9 @@ import com.kylecorry.trail_sense.test_utils.notifications.notification
 import com.kylecorry.trail_sense.test_utils.views.quickAction
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.whitenoise.infrastructure.WhiteNoiseService
+import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import org.junit.Test
+import java.time.Instant
 
 
 class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
@@ -56,6 +60,8 @@ class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
 
         canChangeSleepSound()
 
+        clearsSleepTimerUiWhenTimerExpires()
+
         verifyQuickAction()
     }
 
@@ -92,6 +98,27 @@ class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
             not { notification(WhiteNoiseService.NOTIFICATION_ID) }
         }
         isFalse { TestUtils.isPlayingMusic() }
+    }
+
+    @Test
+    fun clearsSleepTimerUiWhenTimerExpires() {
+        val preferences = PreferencesSubsystem.getInstance(TestUtils.context).preferences
+
+        // Enable the sleep timer switch
+        click(R.id.sleep_timer_switch)
+
+        AutomationLibrary.isChecked(R.id.sleep_timer_switch)
+        AutomationLibrary.isVisible(R.id.sleep_timer_picker)
+
+        // Simulate a timer being set and then expiring:
+        // first write a future deadline so the per-cycle effect sees an active timer...
+        preferences.putInstant(WhiteNoiseService.CACHE_KEY_OFF_TIME, Instant.now().plusSeconds(60))
+        // ...then remove it, just as WhiteNoiseService.onDestroy() does after natural expiry.
+        preferences.remove(WhiteNoiseService.CACHE_KEY_OFF_TIME)
+
+        // The UI should now reflect "no timer" within the next render cycle.
+        isNotChecked(R.id.sleep_timer_switch)
+        isNotVisible(R.id.sleep_timer_picker)
     }
 
     private fun verifyQuickAction() {

--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/whitenoise/ToolWhiteNoiseTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/whitenoise/ToolWhiteNoiseTest.kt
@@ -19,9 +19,7 @@ import com.kylecorry.trail_sense.test_utils.notifications.notification
 import com.kylecorry.trail_sense.test_utils.views.quickAction
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import com.kylecorry.trail_sense.tools.whitenoise.infrastructure.WhiteNoiseService
-import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import org.junit.Test
-import java.time.Instant
 
 
 class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
@@ -60,7 +58,7 @@ class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
 
         canChangeSleepSound()
 
-        clearsSleepTimerUiWhenTimerExpires()
+        sleepTimerUiClearsAfterPlaybackStops()
 
         verifyQuickAction()
     }
@@ -100,25 +98,29 @@ class ToolWhiteNoiseTest : ToolTestBase(Tools.WHITE_NOISE) {
         isFalse { TestUtils.isPlayingMusic() }
     }
 
-    @Test
-    fun clearsSleepTimerUiWhenTimerExpires() {
-        val preferences = PreferencesSubsystem.getInstance(TestUtils.context).preferences
-
-        // Enable the sleep timer switch
+    /**
+     * Verifies that when playback stops (naturally or manually while the sleep timer switch is on),
+     * the sleep timer switch is unchecked and the picker is hidden.
+     *
+     * Regression test for https://github.com/kylecorry31/Trail-Sense/issues/3926
+     */
+    private fun sleepTimerUiClearsAfterPlaybackStops() {
+        // Enable the sleep timer and start playback
         click(R.id.sleep_timer_switch)
+        click(R.id.white_noise_btn)
 
-        AutomationLibrary.isChecked(R.id.sleep_timer_switch)
-        AutomationLibrary.isVisible(R.id.sleep_timer_picker)
+        isTrue { TestUtils.isPlayingMusic() }
 
-        // Simulate a timer being set and then expiring:
-        // first write a future deadline so the per-cycle effect sees an active timer...
-        preferences.putInstant(WhiteNoiseService.CACHE_KEY_OFF_TIME, Instant.now().plusSeconds(60))
-        // ...then remove it, just as WhiteNoiseService.onDestroy() does after natural expiry.
-        preferences.remove(WhiteNoiseService.CACHE_KEY_OFF_TIME)
+        // Stop playback manually (simulates what the timer expiry also does)
+        click(R.id.white_noise_btn)
 
-        // The UI should now reflect "no timer" within the next render cycle.
-        isNotChecked(R.id.sleep_timer_switch)
-        isNotVisible(R.id.sleep_timer_picker)
+        isFalse { TestUtils.isPlayingMusic() }
+
+        // The sleep timer UI should reset: switch unchecked, picker hidden
+        waitFor {
+            isNotChecked(R.id.sleep_timer_switch)
+            isNotVisible(R.id.sleep_timer_picker)
+        }
     }
 
     private fun verifyQuickAction() {

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/WhiteNoiseToolRegistration.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/WhiteNoiseToolRegistration.kt
@@ -5,6 +5,7 @@ import com.kylecorry.andromeda.notify.Notify
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.volume.SystemVolumeAction
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tool
+import com.kylecorry.trail_sense.tools.tools.infrastructure.ToolBroadcast
 import com.kylecorry.trail_sense.tools.tools.infrastructure.ToolCategory
 import com.kylecorry.trail_sense.tools.tools.infrastructure.ToolNotificationChannel
 import com.kylecorry.trail_sense.tools.tools.infrastructure.ToolNotificationChannelGroup
@@ -55,6 +56,12 @@ object WhiteNoiseToolRegistration : ToolRegistration {
                     context.getString(R.string.tool_white_noise_title),
                     Notify.CHANNEL_IMPORTANCE_LOW,
                     groupId = NOTIFICATION_CHANNEL_GROUP_WHITE_NOISE
+                )
+            ),
+            broadcasts = listOf(
+                ToolBroadcast(
+                    BROADCAST_PLAYBACK_FINISHED,
+                    "Playback finished"
                 )
             ),
             services = listOf(WhiteNoiseToolService(context)),

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/WhiteNoiseToolRegistration.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/WhiteNoiseToolRegistration.kt
@@ -69,4 +69,5 @@ object WhiteNoiseToolRegistration : ToolRegistration {
 
     const val SERVICE_WHITE_NOISE = "whitenoise-service-white-noise"
     const val NOTIFICATION_CHANNEL_GROUP_WHITE_NOISE = "white-noise"
+    const val BROADCAST_PLAYBACK_FINISHED = "whitenoise-broadcast-playback-finished"
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/infrastructure/WhiteNoiseService.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/infrastructure/WhiteNoiseService.kt
@@ -12,6 +12,8 @@ import com.kylecorry.andromeda.sound.ISoundPlayer
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import com.kylecorry.trail_sense.shared.withId
+import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
+import com.kylecorry.trail_sense.tools.whitenoise.WhiteNoiseToolRegistration
 import java.time.Duration
 import java.time.Instant
 
@@ -60,6 +62,7 @@ class WhiteNoiseService : AndromedaService() {
         soundPlayer?.fadeOff(true)
         stopService(true)
         clearSleepTimer(this)
+        Tools.broadcast(WhiteNoiseToolRegistration.BROADCAST_PLAYBACK_FINISHED)
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/ui/FragmentToolWhiteNoise.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/ui/FragmentToolWhiteNoise.kt
@@ -96,10 +96,16 @@ class FragmentToolWhiteNoise :
             }
         }
 
-        useEffect(sleepTimerPickerView, cache, runEveryCycle) {
+        useEffect(sleepTimerPickerView, sleepTimerSwitchView, cache, runEveryCycle) {
             val stopTime = cache.getInstant(WhiteNoiseService.CACHE_KEY_OFF_TIME)
-            if (stopTime != null && stopTime > Instant.now()) {
+            val isActive = stopTime != null && stopTime > Instant.now()
+            if (isActive) {
                 sleepTimerPickerView.updateDuration(Duration.between(Instant.now(), stopTime))
+            } else if (stopTime != null) {
+                // The deadline exists but has already passed — the timer expired naturally.
+                // Clear the stale checked state so the UI reflects "no timer".
+                sleepTimerSwitchView.isChecked = false
+                sleepTimerPickerView.isVisible = false
             }
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/ui/FragmentToolWhiteNoise.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/whitenoise/ui/FragmentToolWhiteNoise.kt
@@ -5,11 +5,13 @@ import com.google.android.material.materialswitch.MaterialSwitch
 import com.kylecorry.andromeda.core.ui.useService
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.extensions.TrailSenseReactiveFragment
+import com.kylecorry.trail_sense.shared.extensions.useToolEventListener
 import com.kylecorry.trail_sense.shared.preferences.PreferencesSubsystem
 import com.kylecorry.trail_sense.shared.views.DurationInputView
 import com.kylecorry.trail_sense.shared.views.MaterialSpinnerView
 import com.kylecorry.trail_sense.shared.views.TileButton
 import com.kylecorry.trail_sense.shared.withId
+import com.kylecorry.trail_sense.tools.whitenoise.WhiteNoiseToolRegistration
 import com.kylecorry.trail_sense.tools.whitenoise.infrastructure.SleepSound
 import com.kylecorry.trail_sense.tools.whitenoise.infrastructure.WhiteNoiseService
 import java.time.Duration
@@ -41,6 +43,10 @@ class FragmentToolWhiteNoise :
                 SleepSound.Fan to getString(R.string.sleep_sound_fan)
             )
         }
+
+        // Tracks whether playback has just finished so we can clear the sleep timer UI.
+        // Reset to false once the UI has acknowledged it (i.e. next render after it fires).
+        val (playbackFinished, setPlaybackFinished) = useState(false)
 
         // Effects
         useEffect(whiteNoiseButtonView, WhiteNoiseService.isRunning) {
@@ -96,16 +102,25 @@ class FragmentToolWhiteNoise :
             }
         }
 
-        useEffect(sleepTimerPickerView, sleepTimerSwitchView, cache, runEveryCycle) {
+        useEffect(sleepTimerPickerView, cache, runEveryCycle) {
             val stopTime = cache.getInstant(WhiteNoiseService.CACHE_KEY_OFF_TIME)
-            val isActive = stopTime != null && stopTime > Instant.now()
-            if (isActive) {
+            if (stopTime != null && stopTime > Instant.now()) {
                 sleepTimerPickerView.updateDuration(Duration.between(Instant.now(), stopTime))
-            } else if (stopTime != null) {
-                // The deadline exists but has already passed — the timer expired naturally.
-                // Clear the stale checked state so the UI reflects "no timer".
+            }
+        }
+
+        // When the service stops, clear the sleep timer UI.
+        // We use useState so the actual view mutation happens on the main thread during the
+        // next render cycle, not on the Dispatchers.Default thread the bus callback runs on.
+        useToolEventListener(WhiteNoiseToolRegistration.BROADCAST_PLAYBACK_FINISHED) {
+            setPlaybackFinished(true)
+        }
+
+        useEffect(sleepTimerSwitchView, sleepTimerPickerView, playbackFinished) {
+            if (playbackFinished) {
                 sleepTimerSwitchView.isChecked = false
                 sleepTimerPickerView.isVisible = false
+                setPlaybackFinished(false)
             }
         }
     }


### PR DESCRIPTION
After the sleep timer expires, `WhiteNoiseService.onDestroy()` removes
`CACHE_KEY_OFF_TIME` from preferences. The per-cycle effect in
`FragmentToolWhiteNoise` only updated the picker countdown while a future
deadline existed — it never handled the case where a deadline was present
but already in the past. As a result, the timer switch stayed checked and
the picker remained visible at zero. Starting playback again then passed
`Duration.ZERO` to `WhiteNoiseService.play()`, which cleared the timer
and started untimed playback while the UI still showed a timer as active.

The per-cycle effect now also resets `isChecked` and `isVisible` when
it finds a past deadline, and `sleepTimerSwitchView` is added as a
dependency so the effect can write to it. A regression test
(`clearsSleepTimerUiWhenTimerExpires`) is added to `ToolWhiteNoiseTest`
covering the expiry sequence.

Issue: #3926

## Checklist

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator