### PR TITLE
Increase padding below destination bearing (#3918)

### DIFF
--- a/app/src/main/res/layout/view_navigation_sheet.xml
+++ b/app/src/main/res/layout/view_navigation_sheet.xml
@@ -19,6 +19,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
+        android:paddingBottom="@dimen/default_bottom_margin"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 


### PR DESCRIPTION
Added `paddingBottom` of 16dp to the data views container in `view_navigation_sheet.xml`. Previously, when navigating by bearing, the single bearing value (e.g. "13° N") had no bottom padding, making it appear cut off at the edge of the sheet.

<img width="1600" height="896" alt="Screenshot_2026-08-03_12-46-28" src="https://github.com/user-attachments/assets/1292dfb6-6803-462e-8f44-386c5030b207" />

Issue: #3918

## Checklist

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator