### PR TITLE
fix: hide delete option for temporary beacons on details screen

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/beacons/ui/BeaconDetailsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/beacons/ui/BeaconDetailsFragment.kt
@@ -239,3 +239,4 @@ class BeaconDetailsFragment : BoundFragment<FragmentBeaconDetailsBinding>() {
         return FragmentBeaconDetailsBinding.inflate(layoutInflater, container, false)
     }
 }
+

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/beacons/ui/BeaconDetailsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/beacons/ui/BeaconDetailsFragment.kt
@@ -105,10 +105,12 @@ class BeaconDetailsFragment : BoundFragment<FragmentBeaconDetailsBinding>() {
                     }
 
                     binding.beaconTitle.rightButton.setOnClickListener {
-                        Pickers.menu(
-                            it,
+                        val menuItems = if (temporary) {
+                            listOf(getString(R.string.share_ellipsis))
+                        } else {
                             listOf(getString(R.string.share_ellipsis), getString(R.string.delete))
-                        ) { idx ->
+                        }
+                        Pickers.menu(it, menuItems) { idx ->
                             when (idx) {
                                 0 -> {
                                     BeaconSender(this@BeaconDetailsFragment).send(this)
@@ -237,4 +239,3 @@ class BeaconDetailsFragment : BoundFragment<FragmentBeaconDetailsBinding>() {
         return FragmentBeaconDetailsBinding.inflate(layoutInflater, container, false)
     }
 }
-


### PR DESCRIPTION
Temporary beacons (such as the "Last signal" cell beacon created by Backtrack) could be deleted through the details screen's overflow menu, even though the beacon list deliberately omits the Delete option for them. This meant a user could remove a system-managed beacon through a path the list was designed to prevent.
 
The fix conditionally builds the details screen menu based on `beacon.temporary`, matching the existing behaviour in `BeaconListItemMapper`.
 
## Screenshot
 
**After** — only Share… is shown for a temporary beacon:
 
<img width="1600" height="896" alt="Screenshot_2026-08-04_13-00-30" src="https://github.com/user-attachments/assets/c4501c53-eb6f-4ed1-9d32-0c1fdb967aae" />

> Navigate, Share… — no Delete ✓
 
Issue: #3940
 
## Checklist
 
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
 
