### PR TITLE
feat: allow adjusting set bearing length in Navigation settings

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/domain/Destination.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/domain/Destination.kt
@@ -28,8 +28,8 @@ sealed class Destination {
             }
 
         companion object {
-            /** Default 5 km bearing line length (used when no preference is configured). */
             val defaultBearingDistance: Distance = Distance.kilometers(5f).meters()
+            val maxBearingDistance: Distance = Distance.kilometers(20f).meters()
             val defaultColor: Int = AppColor.Blue.color
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/domain/Destination.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/domain/Destination.kt
@@ -9,7 +9,8 @@ sealed class Destination {
         val bearing: com.kylecorry.sol.units.Bearing,
         val isTrueNorth: Boolean,
         val declination: Float,
-        val startingLocation: Coordinate? = null
+        val startingLocation: Coordinate? = null,
+        val bearingDistance: Distance = defaultBearingDistance
     ) : Destination() {
 
         val trueBearing: com.kylecorry.sol.units.Bearing
@@ -27,7 +28,8 @@ sealed class Destination {
             }
 
         companion object {
-            val bearingDistance: Distance = Distance.kilometers(5f).meters()
+            /** Default 5 km bearing line length (used when no preference is configured). */
+            val defaultBearingDistance: Distance = Distance.kilometers(5f).meters()
             val defaultColor: Int = AppColor.Blue.color
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/NavigationPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/NavigationPreferences.kt
@@ -20,6 +20,7 @@ import com.kylecorry.trail_sense.tools.paths.domain.PathPointColoringStyle
 import com.kylecorry.trail_sense.tools.paths.domain.PathStyle
 import com.kylecorry.trail_sense.tools.paths.infrastructure.persistence.IPathPreferences
 import com.kylecorry.trail_sense.tools.paths.ui.PathSortMethod
+import com.kylecorry.trail_sense.tools.navigation.domain.Destination
 import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import java.time.Duration
 
@@ -229,20 +230,23 @@ class NavigationPreferences(private val context: Context) : ICompassStylePrefere
         false
     )
 
-    var bearingDistance: Float
+    var bearingDistance: Distance
         get() {
-            val raw =
-                cache.getString(context.getString(R.string.pref_bearing_distance)) ?: "5.0"
-            return Distance.kilometers(raw.toFloatCompat() ?: 5.0f)
-                .meters()
-                .value
-                .coerceIn(100f, 25000000f)
+            val raw = cache.getString(context.getString(R.string.pref_bearing_distance)) ?: "5.0"
+            return Distance.meters(
+                Distance.kilometers(raw.toFloatCompat() ?: 5.0f)
+                    .meters()
+                    .value
+                    .coerceIn(1f, Destination.Bearing.maxBearingDistance.value)
+            )
         }
         set(value) {
-            val meters = Distance.meters(value.coerceIn(100f, 25000000f))
+            val km = value.meters().value
+                .coerceIn(1f, Destination.Bearing.maxBearingDistance.value)
+                .let { Distance.meters(it).convertTo(DistanceUnits.Kilometers).value }
             cache.putString(
                 context.getString(R.string.pref_bearing_distance),
-                meters.convertTo(DistanceUnits.Kilometers).value.toString()
+                km.toString()
             )
         }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/NavigationPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/NavigationPreferences.kt
@@ -229,6 +229,23 @@ class NavigationPreferences(private val context: Context) : ICompassStylePrefere
         false
     )
 
+    var bearingDistance: Float
+        get() {
+            val raw =
+                cache.getString(context.getString(R.string.pref_bearing_distance)) ?: "5.0"
+            return Distance.kilometers(raw.toFloatCompat() ?: 5.0f)
+                .meters()
+                .value
+                .coerceIn(100f, 25000000f)
+        }
+        set(value) {
+            val meters = Distance.meters(value.coerceIn(100f, 25000000f))
+            cache.putString(
+                context.getString(R.string.pref_bearing_distance),
+                meters.convertTo(DistanceUnits.Kilometers).value.toString()
+            )
+        }
+
     enum class SpeedometerMode {
         Backtrack,
         GPS,

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/Navigator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/Navigator.kt
@@ -68,7 +68,7 @@ class Navigator private constructor(context: Context) {
                 userPrefs.compass.useTrueNorth,
                 declination,
                 it.startLocation,
-                Distance.meters(userPrefs.navigation.bearingDistance)
+                userPrefs.navigation.bearingDistance
             )
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/Navigator.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/infrastructure/Navigator.kt
@@ -67,7 +67,8 @@ class Navigator private constructor(context: Context) {
                 Bearing.from(it.bearing),
                 userPrefs.compass.useTrueNorth,
                 declination,
-                it.startLocation
+                it.startLocation,
+                Distance.meters(userPrefs.navigation.bearingDistance)
             )
         }
     }

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/map_layers/NavigationGeoJsonSource.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/map_layers/NavigationGeoJsonSource.kt
@@ -80,7 +80,7 @@ class NavigationGeoJsonSource : GeoJsonSource {
             listOf(
                 createPath(
                     myLocation,
-                    myLocation.plus(Destination.Bearing.bearingDistance, bearing.trueBearing),
+                    myLocation.plus(bearing.bearingDistance, bearing.trueBearing),
                     Destination.Bearing.defaultColor
                 )
             )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/NavigationSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/NavigationSettingsFragment.kt
@@ -8,6 +8,8 @@ import com.kylecorry.andromeda.fragments.show
 import com.kylecorry.sol.units.Distance
 import com.kylecorry.trail_sense.R
 import com.kylecorry.trail_sense.shared.DistanceUtils
+import com.kylecorry.trail_sense.shared.FormatService
+import com.kylecorry.trail_sense.tools.navigation.domain.Destination
 import com.kylecorry.trail_sense.shared.DistanceUtils.toRelativeDistance
 import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.map_layers.preferences.ui.MapLayersBottomSheet
@@ -60,16 +62,22 @@ class NavigationSettingsFragment : AndromedaPreferenceFragment() {
             DistanceUtils.hikingDistanceUnits
         )
 
+        val maxBearingDistanceFormatted = relative(
+            Destination.Bearing.maxBearingDistance,
+            userPrefs
+        ).let { FormatService.getInstance(requireContext()).formatDistance(it) }
+
         setupDistanceSetting(
             getString(R.string.pref_bearing_distance_holder),
-            { relative(Distance.meters(userPrefs.navigation.bearingDistance), userPrefs) },
+            { relative(userPrefs.navigation.bearingDistance, userPrefs) },
             { distance ->
                 if (distance != null && distance.value > 0) {
-                    userPrefs.navigation.bearingDistance = distance.meters().value
+                    userPrefs.navigation.bearingDistance = distance
                 }
             },
             DistanceUtils.hikingDistanceUnits,
-            description = getString(R.string.bearing_length_description)
+            description = getString(R.string.bearing_length_description) +
+                    "\n" + getString(R.string.bearing_length_max, maxBearingDistanceFormatted)
         )
 
         editText(R.string.pref_num_visible_beacons)

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/NavigationSettingsFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/navigation/ui/NavigationSettingsFragment.kt
@@ -60,6 +60,18 @@ class NavigationSettingsFragment : AndromedaPreferenceFragment() {
             DistanceUtils.hikingDistanceUnits
         )
 
+        setupDistanceSetting(
+            getString(R.string.pref_bearing_distance_holder),
+            { relative(Distance.meters(userPrefs.navigation.bearingDistance), userPrefs) },
+            { distance ->
+                if (distance != null && distance.value > 0) {
+                    userPrefs.navigation.bearingDistance = distance.meters().value
+                }
+            },
+            DistanceUtils.hikingDistanceUnits,
+            description = getString(R.string.bearing_length_description)
+        )
+
         editText(R.string.pref_num_visible_beacons)
             ?.setOnBindEditTextListener { editText ->
                 editText.inputType = InputType.TYPE_CLASS_NUMBER

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1936,6 +1936,10 @@
     <string name="pref_lock_bearing_to_location" translatable="false">pref_lock_bearing_to_location</string>
     <string name="lock_bearing_to_location">Lock bearing to location</string>
     <string name="lock_bearing_to_location_description">Lock the bearing line to your starting location</string>
+    <string name="pref_bearing_distance_holder" translatable="false">pref_bearing_distance_holder</string>
+    <string name="pref_bearing_distance" translatable="false">pref_bearing_distance</string>
+    <string name="bearing_length">Set bearing length</string>
+    <string name="bearing_length_description">The length of the bearing line when a set bearing is active</string>
     <string name="pref_show_astronomy_bands_title">Show sunrise/set bands</string>
     <string name="pref_show_astronomy_bands" translatable="false">pref_show_astronomy_bands</string>
     <string name="settings_copied">Settings copied</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1940,6 +1940,7 @@
     <string name="pref_bearing_distance" translatable="false">pref_bearing_distance</string>
     <string name="bearing_length">Set bearing length</string>
     <string name="bearing_length_description">The length of the bearing line when a set bearing is active</string>
+    <string name="bearing_length_max">Max: %s</string>
     <string name="pref_show_astronomy_bands_title">Show sunrise/set bands</string>
     <string name="pref_show_astronomy_bands" translatable="false">pref_show_astronomy_bands</string>
     <string name="settings_copied">Settings copied</string>

--- a/app/src/main/res/xml/navigation_preferences.xml
+++ b/app/src/main/res/xml/navigation_preferences.xml
@@ -56,6 +56,12 @@
             app:summary="@string/lock_bearing_to_location_description"
             app:title="@string/lock_bearing_to_location" />
 
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="@string/pref_bearing_distance_holder"
+            app:singleLineTitle="false"
+            app:title="@string/bearing_length" />
+
         <ListPreference
             android:entries="@array/speedometer_entries"
             android:entryValues="@array/speedometer_values"


### PR DESCRIPTION
When a bearing is set in the Navigation tool, the bearing line was hardcoded to 5 km. This was confusing for users who set short bearings (the line extends far past any visible landmark) or long-distance navigation (the line ends too early). This change adds a **"Set bearing length"** preference under Navigation settings so users can configure the distance to match their use case.
 
The default remains 5 km so existing behaviour is unchanged for anyone who doesn't touch the setting.
 
Issue: #3879
 
 
## Checklist
 
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
 
