### PR TITLE
shared: create a shared tile cache with separate layer caches

### DIFF
--- a/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/UserPreferences.kt
@@ -114,6 +114,12 @@ class UserPreferences(ctx: Context) : IDeclinationPreferences {
         false
     )
 
+    val useLargeTileCache by BooleanPreference(
+        cache,
+        context.getString(R.string.pref_large_tile_cache),
+        false
+    )
+
     var isCliffHeightEnabled by BooleanPreference(
         cache,
         context.getString(R.string.pref_cliff_height_enabled),

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/ImageTile.kt
@@ -10,6 +10,7 @@ class ImageTile(
     @Volatile private var image: Bitmap? = null,
     state: TileState = TileState.Idle,
     private val shouldFadeIn: Boolean = true,
+    val owner: String = "",
     loadFunction: (suspend () -> Bitmap?)?
 ) {
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
@@ -1,0 +1,130 @@
+package com.kylecorry.trail_sense.shared.map_layers.tiles
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+class LayerTileCache(
+    val source: String,
+    maxSize: Int
+) {
+
+    // This lock coordinates normal cache operations with whole-layer lifecycle operations. A read lock does not mean
+    // the cache is immutable: it allows thread-safe LRU mutations to run concurrently while preventing clear or
+    // invalidation. The write lock gives those lifecycle operations exclusive access to both cache tiers.
+    private val lifecycleLock = ReentrantReadWriteLock()
+    private val layerCache = TileCache(source, maxSize) { tile ->
+        if (isCacheable(tile)) {
+            sharedCache.store(tile.key, tile)
+        } else {
+            recycle(tile)
+        }
+    }
+
+    operator fun get(tile: Tile): ImageTile? {
+        return layerCache[tile]
+    }
+
+    fun peek(tile: Tile): ImageTile? {
+        val key = getKey(tile)
+        return layerCache.peek(key) ?: sharedCache.peek(key)
+    }
+
+    fun getOrPut(tile: Tile, provider: (key: String) -> ImageTile): ImageTile {
+        // Acquiring a tile can update LRU ordering and transfer ownership, but it can run alongside other normal use.
+        return lifecycleLock.read {
+            getOrPutLocked(tile, provider)
+        }
+    }
+
+    fun getOrPut(
+        tiles: List<Tile>,
+        provider: (tile: Tile, key: String) -> ImageTile
+    ): List<ImageTile> {
+        // Batch normal cache mutations under one shared lock acquisition for the rendering hot path.
+        return lifecycleLock.read {
+            tiles.map { tile ->
+                getOrPutLocked(tile) { key -> provider(tile, key) }
+            }
+        }
+    }
+
+    fun onLoadComplete(tile: ImageTile) {
+        if (!isCacheable(tile)) {
+            sharedCache.removeIfSame(tile.key, tile)
+        }
+    }
+
+    fun clear() {
+        lifecycleLock.write {
+            layerCache.evictAll()
+            sharedCache.evictOwner(source)
+        }
+    }
+
+    fun invalidate() {
+        lifecycleLock.write {
+            layerCache.snapshot().values.forEach { it.invalidate() }
+            sharedCache.invalidateOwner(source)
+        }
+    }
+
+    fun resize(maxSize: Int) {
+        // Resizing mutates the thread-safe LRU, but only needs to be excluded from whole-layer lifecycle operations.
+        lifecycleLock.read {
+            layerCache.resize(maxSize)
+        }
+    }
+
+    fun maxSize(): Int {
+        return layerCache.maxSize()
+    }
+
+    fun sizeBytes(): Long {
+        return layerCache.sizeBytes()
+    }
+
+    fun sharedSizeBytes(): Long {
+        return sharedCache.sizeBytes()
+    }
+
+    private fun getOrPutLocked(tile: Tile, provider: (key: String) -> ImageTile): ImageTile {
+        val key = getKey(tile)
+        return layerCache.getOrPut(key) {
+            takeShared(key) ?: provider(key)
+        }
+    }
+
+    private fun takeShared(key: String): ImageTile? {
+        val tile = sharedCache.take(key) ?: return null
+        if (isCacheable(tile)) {
+            return tile
+        }
+        recycle(tile)
+        return null
+    }
+
+    private fun getKey(tile: Tile): String {
+        return "${source}_${tile.x}_${tile.y}_${tile.z}"
+    }
+
+    private fun isCacheable(tile: ImageTile): Boolean {
+        return tile.hasImage() || tile.state == TileState.Loading
+    }
+
+    companion object {
+        private val recycleScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        private val sharedCache = TileCache("", SHARED_CACHE_SIZE) { recycle(it) }
+        private const val SHARED_CACHE_SIZE = 256
+
+        private fun recycle(tile: ImageTile) {
+            recycleScope.launch {
+                tile.recycle()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
@@ -61,7 +61,7 @@ class LayerTileCache(
 
     fun clear() {
         lifecycleLock.write {
-            layerCache.evictAll()
+            layerCache.takeAll().forEach { recycle(it) }
             sharedCache.evictOwner(source)
         }
     }
@@ -113,7 +113,7 @@ class LayerTileCache(
     }
 
     private fun isCacheable(tile: ImageTile): Boolean {
-        return tile.hasImage() || tile.state == TileState.Loading
+        return tile.hasImage() || tile.state == TileState.Loading || tile.state == TileState.Empty
     }
 
     companion object {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCache.kt
@@ -34,13 +34,6 @@ class LayerTileCache(
         return layerCache.peek(key) ?: sharedCache.peek(key)
     }
 
-    fun getOrPut(tile: Tile, provider: (key: String) -> ImageTile): ImageTile {
-        // Acquiring a tile can update LRU ordering and transfer ownership, but it can run alongside other normal use.
-        return lifecycleLock.read {
-            getOrPutLocked(tile, provider)
-        }
-    }
-
     fun getOrPut(
         tiles: List<Tile>,
         provider: (tile: Tile, key: String) -> ImageTile

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
@@ -83,6 +83,17 @@ class TileCache(
         }
     }
 
+    fun takeAll(): List<ImageTile> {
+        synchronized(this) {
+            return snapshot().keys.mapNotNull {
+                val value = get(it) ?: return@mapNotNull null
+                transferring[it] = value
+                remove(it)
+                value
+            }
+        }
+    }
+
     fun removeIfSame(key: String, tile: ImageTile): Boolean {
         synchronized(this) {
             if (entries[key] !== tile) {

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
@@ -29,8 +29,8 @@ class TileCache(
         return get(getKey(tile))
     }
 
-    fun peek(tile: Tile): ImageTile? {
-        return entries[getKey(tile)]
+    fun peek(key: String): ImageTile? {
+        return entries[key]
     }
 
     fun getOrPut(key: String, provider: () -> ImageTile): ImageTile {
@@ -80,6 +80,16 @@ class TileCache(
             transferring[key] = value
             remove(key)
             return value
+        }
+    }
+
+    fun removeIfSame(key: String, tile: ImageTile): Boolean {
+        synchronized(this) {
+            if (entries[key] !== tile) {
+                return false
+            }
+            remove(key)
+            return true
         }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileCache.kt
@@ -3,9 +3,14 @@ package com.kylecorry.trail_sense.shared.map_layers.tiles
 import androidx.collection.LruCache
 import java.util.concurrent.ConcurrentHashMap
 
-class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(maxSize) {
+class TileCache(
+    val source: String,
+    maxSize: Int,
+    private val removalListener: (ImageTile) -> Unit = { it.recycle() }
+) : LruCache<String, ImageTile>(maxSize) {
 
     private val entries = ConcurrentHashMap<String, ImageTile>()
+    private val transferring = ConcurrentHashMap<String, ImageTile>()
 
     override fun entryRemoved(
         evicted: Boolean,
@@ -15,7 +20,9 @@ class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(
     ) {
         super.entryRemoved(evicted, key, oldValue, newValue)
         entries.remove(key, oldValue)
-        oldValue.recycle()
+        if (!transferring.remove(key, oldValue)) {
+            removalListener(oldValue)
+        }
     }
 
     operator fun get(tile: Tile): ImageTile? {
@@ -36,6 +43,43 @@ class TileCache(val source: String, maxSize: Int) : LruCache<String, ImageTile>(
             put(key, newValue)
             entries[key] = newValue
             return newValue
+        }
+    }
+
+    fun store(key: String, tile: ImageTile) {
+        synchronized(this) {
+            put(key, tile)
+            entries[key] = tile
+        }
+    }
+
+    fun evictOwner(owner: String) {
+        synchronized(this) {
+            val keys = snapshot().filterValues { it.owner == owner }.keys
+            keys.forEach { remove(it) }
+        }
+    }
+
+    fun invalidateOwner(owner: String) {
+        snapshot().values.filter { it.owner == owner }.forEach { it.invalidate() }
+    }
+
+    fun sizeBytes(): Long {
+        var bytes = 0L
+        snapshot().values.forEach { tile ->
+            tile.withImage { image ->
+                bytes += image?.allocationByteCount?.toLong() ?: 0L
+            }
+        }
+        return bytes
+    }
+
+    fun take(key: String): ImageTile? {
+        synchronized(this) {
+            val value = get(key) ?: return null
+            transferring[key] = value
+            remove(key)
+            return value
         }
     }
 

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -38,7 +38,11 @@ class TileLoader(
     private val prefs = getAppService<UserPreferences>()
 
     val tileCache = TileCache(owner, 1) { tile ->
-        sharedTileCache.store(tile.key, tile)
+        if (tile.hasImage() || tile.state == TileState.Loading) {
+            sharedTileCache.store(tile.key, tile)
+        } else {
+            tile.recycle()
+        }
     }
 
     private val persistentCache =

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -37,13 +37,7 @@ class TileLoader(
     private val debugLogs = false
     private val prefs = getAppService<UserPreferences>()
 
-    val tileCache = TileCache(owner, 1) { tile ->
-        if (tile.hasImage() || tile.state == TileState.Loading) {
-            sharedTileCache.store(tile.key, tile)
-        } else {
-            tile.recycle()
-        }
-    }
+    val tileCache = LayerTileCache(owner, 1)
 
     private val persistentCache =
         if (key != null) getAppService<PersistentTileCache>() else null
@@ -66,6 +60,7 @@ class TileLoader(
     init {
         // TODO: This should be handled by a higher level component
         tileQueue.setChangeListener { imageTile ->
+            tileCache.onLoadComplete(imageTile)
             tryOrLog {
                 populateBorderAndNeighbors(imageTile)
             }
@@ -74,7 +69,7 @@ class TileLoader(
                 Log.d(
                     "TileCache",
                     "Layer cache ($owner): ${formatter.formatFileSize(tileCache.sizeBytes())}, " +
-                            "shared cache: ${formatter.formatFileSize(sharedTileCache.sizeBytes())}"
+                            "shared cache: ${formatter.formatFileSize(tileCache.sharedSizeBytes())}"
                 )
             }
             updateListener()
@@ -82,13 +77,11 @@ class TileLoader(
     }
 
     fun clearCache() {
-        tileCache.evictAll()
-        sharedTileCache.evictOwner(owner)
+        tileCache.clear()
     }
 
     fun invalidateCache() {
-        tileCache.snapshot().values.forEach { it.invalidate() }
-        sharedTileCache.invalidateOwner(owner)
+        tileCache.invalidate()
     }
 
     fun loadTiles(
@@ -116,24 +109,22 @@ class TileLoader(
             putBundle(MapLayerParams.PARAM_PREFERENCES, Bundle(preferences))
         }
         featureId?.let { params.putString(MapLayerParams.PARAM_FEATURE_ID, it) }
-        val imageTiles = tiles.map { tile ->
-            val key = "${tag}_${tile.x}_${tile.y}_${tile.z}"
-            val newTile = tileCache.getOrPut(key) {
-                sharedTileCache.take(key) ?: ImageTile(
-                    key = key,
-                    tile = tile,
-                    shouldFadeIn = !isWidget,
-                    owner = owner,
-                    loadFunction = {
-                        loadTile(source, context, tile, params)
-                    }
-                )
-            }
+        val imageTiles = tileCache.getOrPut(tiles) { tile, key ->
+            ImageTile(
+                key = key,
+                tile = tile,
+                shouldFadeIn = !isWidget,
+                owner = owner,
+                loadFunction = {
+                    loadTile(source, context, tile, params)
+                }
+            )
+        }
+        imageTiles.forEach { imageTile ->
             // Replace the load function every cycle to ensure it uses the latest parameters
-            newTile.setLoader {
-                loadTile(source, context, tile, params)
+            imageTile.setLoader {
+                loadTile(source, context, imageTile.tile, params)
             }
-            newTile
         }
 
         imageTiles.forEach { tileQueue.enqueue(it) }
@@ -380,9 +371,7 @@ class TileLoader(
     }
 
     companion object {
-        private val sharedTileCache = TileCache("", SHARED_CACHE_SIZE)
         private const val LARGE_LAYER_CACHE_SIZE = 256
-        private const val SHARED_CACHE_SIZE = 256
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -374,14 +374,6 @@ class TileLoader(
     companion object {
         private const val LARGE_LAYER_CACHE_SIZE = 256
 
-        internal fun getCacheSize(tileCount: Int, useLargeCache: Boolean): Int {
-            val screenCacheSize = (tileCount * 2).coerceAtLeast(1)
-            return if (useLargeCache) {
-                maxOf(LARGE_LAYER_CACHE_SIZE, screenCacheSize)
-            } else {
-                screenCacheSize
-            }
-        }
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -9,6 +9,7 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.os.Bundle
+import android.util.Log
 import com.kylecorry.andromeda.bitmaps.BitmapUtils.use
 import com.kylecorry.andromeda.bitmaps.operations.Pad
 import com.kylecorry.andromeda.bitmaps.operations.Resize
@@ -16,6 +17,8 @@ import com.kylecorry.andromeda.bitmaps.operations.applyOperationsOrNull
 import com.kylecorry.andromeda.core.tryOrLog
 import com.kylecorry.andromeda.core.tryOrNothing
 import com.kylecorry.trail_sense.main.getAppService
+import com.kylecorry.trail_sense.shared.FormatService
+import com.kylecorry.trail_sense.shared.UserPreferences
 import com.kylecorry.trail_sense.shared.map_layers.tiles.infrastructure.persistance.PersistentTileCache
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.MapLayerParams
 import com.kylecorry.trail_sense.shared.map_layers.ui.layers.tiles.TileSource
@@ -30,7 +33,13 @@ class TileLoader(
     private val updateListener: () -> Unit = {}
 ) {
 
-    val tileCache = TileCache(tag ?: "", STANDARD_DETAIL_CACHE_SIZE)
+    private val owner = tag ?: ""
+    private val debugLogs = false
+    private val prefs = getAppService<UserPreferences>()
+
+    val tileCache = TileCache(owner, 1) { tile ->
+        sharedTileCache.store(tile.key, tile)
+    }
 
     private val persistentCache =
         if (key != null) getAppService<PersistentTileCache>() else null
@@ -56,12 +65,26 @@ class TileLoader(
             tryOrLog {
                 populateBorderAndNeighbors(imageTile)
             }
+            if (debugLogs) {
+                val formatter = getAppService<FormatService>()
+                Log.d(
+                    "TileCache",
+                    "Layer cache ($owner): ${formatter.formatFileSize(tileCache.sizeBytes())}, " +
+                            "shared cache: ${formatter.formatFileSize(sharedTileCache.sizeBytes())}"
+                )
+            }
             updateListener()
         }
     }
 
     fun clearCache() {
         tileCache.evictAll()
+        sharedTileCache.evictOwner(owner)
+    }
+
+    fun invalidateCache() {
+        tileCache.snapshot().values.forEach { it.invalidate() }
+        sharedTileCache.invalidateOwner(owner)
     }
 
     fun loadTiles(
@@ -71,11 +94,13 @@ class TileLoader(
         featureId: String? = null,
         isWidget: Boolean = false,
         isHighDetailMode: Boolean = false,
-        useHighDetailCache: Boolean = isHighDetailMode,
         context: Context
     ) {
-        val cacheSize =
-            if (useHighDetailCache) HIGH_DETAIL_CACHE_SIZE else STANDARD_DETAIL_CACHE_SIZE
+        val cacheSize = if (prefs.useLargeTileCache) {
+            LARGE_LAYER_CACHE_SIZE
+        } else {
+            (tiles.size * 2).coerceAtLeast(1)
+        }
         if (tileCache.maxSize() != cacheSize) {
             tileCache.resize(cacheSize)
         }
@@ -90,10 +115,11 @@ class TileLoader(
         val imageTiles = tiles.map { tile ->
             val key = "${tag}_${tile.x}_${tile.y}_${tile.z}"
             val newTile = tileCache.getOrPut(key) {
-                ImageTile(
+                sharedTileCache.take(key) ?: ImageTile(
                     key = key,
                     tile = tile,
                     shouldFadeIn = !isWidget,
+                    owner = owner,
                     loadFunction = {
                         loadTile(source, context, tile, params)
                     }
@@ -350,8 +376,9 @@ class TileLoader(
     }
 
     companion object {
-        private const val STANDARD_DETAIL_CACHE_SIZE = 150
-        private const val HIGH_DETAIL_CACHE_SIZE = 256
+        private val sharedTileCache = TileCache("", SHARED_CACHE_SIZE)
+        private const val LARGE_LAYER_CACHE_SIZE = 256
+        private const val SHARED_CACHE_SIZE = 256
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/tiles/TileLoader.kt
@@ -93,10 +93,11 @@ class TileLoader(
         isHighDetailMode: Boolean = false,
         context: Context
     ) {
+        val screenCacheSize = (tiles.size * 2).coerceAtLeast(1)
         val cacheSize = if (prefs.useLargeTileCache) {
-            LARGE_LAYER_CACHE_SIZE
+            maxOf(LARGE_LAYER_CACHE_SIZE, screenCacheSize)
         } else {
-            (tiles.size * 2).coerceAtLeast(1)
+            screenCacheSize
         }
         if (tileCache.maxSize() != cacheSize) {
             tileCache.resize(cacheSize)
@@ -372,6 +373,15 @@ class TileLoader(
 
     companion object {
         private const val LARGE_LAYER_CACHE_SIZE = 256
+
+        internal fun getCacheSize(tileCount: Int, useLargeCache: Boolean): Int {
+            val screenCacheSize = (tileCount * 2).coerceAtLeast(1)
+            return if (useLargeCache) {
+                maxOf(LARGE_LAYER_CACHE_SIZE, screenCacheSize)
+            } else {
+                screenCacheSize
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -40,6 +40,7 @@ import com.kylecorry.trail_sense.tools.tools.infrastructure.Tools
 import kotlinx.coroutines.CoroutineScope
 import java.time.Duration
 import java.time.Instant
+import java.util.UUID
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -55,6 +56,7 @@ open class TileMapLayer<T : TileSource>(
     private val refreshBroadcasts: List<String> = emptyList(),
     private val cacheKeys: List<String>? = null
 ) : IAsyncLayer {
+    private val runtimeId = UUID.randomUUID().toString()
     private var _timeOverride: Instant? = null
     private var _renderTime: Instant = Instant.now()
     override var isLoaded: Boolean = false
@@ -471,7 +473,7 @@ open class TileMapLayer<T : TileSource>(
             source,
             queue,
             TILE_BORDER_PIXELS,
-            tag = layerId,
+            tag = "$layerId-$runtimeId",
             key = getCacheKey()
         ) {
             notifyListeners()

--- a/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/shared/map_layers/ui/layers/tiles/TileMapLayer.kt
@@ -207,7 +207,6 @@ open class TileMapLayer<T : TileSource>(
                 featureId,
                 map.isWidget,
                 isHighDetailMode = map.isHighDetailMode,
-                useHighDetailCache = map.isHighDetailMode || zoomOffset > 0,
                 context = context
             )
         } else if (desiredTiles.size > MAX_TILES) {
@@ -502,9 +501,7 @@ open class TileMapLayer<T : TileSource>(
         refreshTime()
         loadTimer.stop()
         queue.clear()
-        loader?.tileCache?.snapshot()?.forEach {
-            it.value.invalidate()
-        }
+        loader?.invalidateCache()
         isLoaded = false
         loadTimer.interval(100)
         invalidate()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -800,6 +800,8 @@
     <string name="pref_unit_settings" translatable="false">pref_unit_settings</string>
     <string name="pref_experimental_metal_direction" translatable="false">pref_experimental_metal_direction</string>
     <string name="pref_experimental_metal_direction_title">Show metal direction</string>
+    <string name="pref_large_tile_cache" translatable="false">pref_large_tile_cache</string>
+    <string name="pref_large_tile_cache_title">Use large map tile cache</string>
     <string name="pref_plugins_enabled" translatable="false">pref_plugins_enabled</string>
     <string name="pref_experimental_settings" translatable="false">pref_experimental_settings</string>
     <string name="pref_sensor_settings" translatable="false">pref_sensor_settings</string>

--- a/app/src/main/res/xml/experimental_preferences.xml
+++ b/app/src/main/res/xml/experimental_preferences.xml
@@ -19,6 +19,13 @@
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:iconSpaceReserved="false"
+            app:key="@string/pref_large_tile_cache"
+            app:singleLineTitle="false"
+            app:title="@string/pref_large_tile_cache_title" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
             app:key="@string/pref_plugins_enabled"
             app:singleLineTitle="false"
             app:title="@string/plugins" />

--- a/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
@@ -3,7 +3,6 @@ package com.kylecorry.trail_sense.shared.map_layers.tiles
 import android.graphics.Bitmap
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -27,7 +26,7 @@ internal class LayerTileCacheTest {
     }
 
     @Test
-    fun removesSharedTileWhenLoadCompletesWithoutImage() = runBlocking {
+    fun keepsSharedTileWhenLoadCompletesWithoutImage() = runBlocking {
         val owner = UUID.randomUUID().toString()
         val cache = LayerTileCache(owner, 1)
         val firstTile = Tile(0, 0, 1)
@@ -46,9 +45,47 @@ internal class LayerTileCacheTest {
         first.load()
         cache.onLoadComplete(first)
 
-        val replacement = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
-        assertNotSame(first, replacement)
-        cache.clear()
+        try {
+            assertEquals(TileState.Empty, first.state)
+            assertSame(
+                first,
+                cache.getOrPut(firstTile) { error("Empty tile was loaded again") }
+            )
+        } finally {
+            cache.clear()
+        }
+    }
+
+    @Test
+    fun clearingLayerDoesNotEvictOtherOwnersFromSharedCache() {
+        val otherOwner = UUID.randomUUID().toString()
+        val clearedOwner = UUID.randomUUID().toString()
+        val otherCache = LayerTileCache(otherOwner, 1)
+        val clearedCache = LayerTileCache(clearedOwner, 1)
+        val sharedTile = Tile(0, 0, 9)
+        val shared = otherCache.getOrPut(sharedTile) { key ->
+            loadedTile(key, sharedTile, otherOwner)
+        }
+        repeat(256) { x ->
+            val tile = Tile(x + 1, 0, 9)
+            otherCache.getOrPut(tile) { key -> loadedTile(key, tile, otherOwner) }
+        }
+        val clearedTile = Tile(0, 1, 9)
+        clearedCache.getOrPut(clearedTile) { key ->
+            loadedTile(key, clearedTile, clearedOwner)
+        }
+
+        try {
+            clearedCache.clear()
+
+            assertSame(
+                shared,
+                otherCache.getOrPut(sharedTile) { error("Other owner's shared tile was evicted") }
+            )
+        } finally {
+            clearedCache.clear()
+            otherCache.clear()
+        }
     }
 
     @Test

--- a/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
@@ -1,0 +1,80 @@
+package com.kylecorry.trail_sense.shared.map_layers.tiles
+
+import android.graphics.Bitmap
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.UUID
+
+internal class LayerTileCacheTest {
+
+    @Test
+    fun movesLoadedTilesBetweenLayerAndSharedCaches() {
+        val owner = UUID.randomUUID().toString()
+        val cache = LayerTileCache(owner, 1)
+        val firstTile = Tile(0, 0, 1)
+        val secondTile = Tile(1, 0, 1)
+        val first = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
+
+        cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+
+        assertSame(first, cache.peek(firstTile))
+        assertSame(first, cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) })
+        cache.clear()
+    }
+
+    @Test
+    fun removesSharedTileWhenLoadCompletesWithoutImage() = runBlocking {
+        val owner = UUID.randomUUID().toString()
+        val cache = LayerTileCache(owner, 1)
+        val firstTile = Tile(0, 0, 1)
+        val secondTile = Tile(1, 0, 1)
+        val first = cache.getOrPut(firstTile) { key ->
+            ImageTile(
+                key = key,
+                tile = firstTile,
+                state = TileState.Loading,
+                owner = owner,
+                loadFunction = { null }
+            )
+        }
+        cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+
+        first.load()
+        cache.onLoadComplete(first)
+
+        val replacement = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
+        assertNotSame(first, replacement)
+        cache.clear()
+    }
+
+    @Test
+    fun invalidatesTilesInBothCaches() {
+        val owner = UUID.randomUUID().toString()
+        val cache = LayerTileCache(owner, 1)
+        val firstTile = Tile(0, 0, 1)
+        val secondTile = Tile(1, 0, 1)
+        val first = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
+        val second = cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+
+        cache.invalidate()
+
+        assertEquals(TileState.Stale, first.state)
+        assertEquals(TileState.Stale, second.state)
+        cache.clear()
+    }
+
+    private fun loadedTile(key: String, tile: Tile, owner: String): ImageTile {
+        return ImageTile(
+            key = key,
+            tile = tile,
+            image = mock<Bitmap>(),
+            state = TileState.Loaded,
+            owner = owner,
+            loadFunction = null
+        )
+    }
+}

--- a/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
+++ b/app/src/test/java/com/kylecorry/trail_sense/shared/map_layers/tiles/LayerTileCacheTest.kt
@@ -16,12 +16,15 @@ internal class LayerTileCacheTest {
         val cache = LayerTileCache(owner, 1)
         val firstTile = Tile(0, 0, 1)
         val secondTile = Tile(1, 0, 1)
-        val first = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
-
-        cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+        val first = cache.getOrPut(listOf(firstTile, secondTile)) { tile, key ->
+            loadedTile(key, tile, owner)
+        }.first()
 
         assertSame(first, cache.peek(firstTile))
-        assertSame(first, cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) })
+        assertSame(
+            first,
+            cache.getOrPut(listOf(firstTile)) { tile, key -> loadedTile(key, tile, owner) }.single()
+        )
         cache.clear()
     }
 
@@ -31,16 +34,19 @@ internal class LayerTileCacheTest {
         val cache = LayerTileCache(owner, 1)
         val firstTile = Tile(0, 0, 1)
         val secondTile = Tile(1, 0, 1)
-        val first = cache.getOrPut(firstTile) { key ->
-            ImageTile(
-                key = key,
-                tile = firstTile,
-                state = TileState.Loading,
-                owner = owner,
-                loadFunction = { null }
-            )
-        }
-        cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+        val first = cache.getOrPut(listOf(firstTile, secondTile)) { tile, key ->
+            if (tile == firstTile) {
+                ImageTile(
+                    key = key,
+                    tile = tile,
+                    state = TileState.Loading,
+                    owner = owner,
+                    loadFunction = { null }
+                )
+            } else {
+                loadedTile(key, tile, owner)
+            }
+        }.first()
 
         first.load()
         cache.onLoadComplete(first)
@@ -49,7 +55,7 @@ internal class LayerTileCacheTest {
             assertEquals(TileState.Empty, first.state)
             assertSame(
                 first,
-                cache.getOrPut(firstTile) { error("Empty tile was loaded again") }
+                cache.getOrPut(listOf(firstTile)) { _, _ -> error("Empty tile was loaded again") }.single()
             )
         } finally {
             cache.clear()
@@ -63,16 +69,13 @@ internal class LayerTileCacheTest {
         val otherCache = LayerTileCache(otherOwner, 1)
         val clearedCache = LayerTileCache(clearedOwner, 1)
         val sharedTile = Tile(0, 0, 9)
-        val shared = otherCache.getOrPut(sharedTile) { key ->
-            loadedTile(key, sharedTile, otherOwner)
-        }
-        repeat(256) { x ->
-            val tile = Tile(x + 1, 0, 9)
-            otherCache.getOrPut(tile) { key -> loadedTile(key, tile, otherOwner) }
-        }
+        val otherTiles = listOf(sharedTile) + (1..256).map { x -> Tile(x, 0, 9) }
+        val shared = otherCache.getOrPut(otherTiles) { tile, key ->
+            loadedTile(key, tile, otherOwner)
+        }.first()
         val clearedTile = Tile(0, 1, 9)
-        clearedCache.getOrPut(clearedTile) { key ->
-            loadedTile(key, clearedTile, clearedOwner)
+        clearedCache.getOrPut(listOf(clearedTile)) { tile, key ->
+            loadedTile(key, tile, clearedOwner)
         }
 
         try {
@@ -80,7 +83,9 @@ internal class LayerTileCacheTest {
 
             assertSame(
                 shared,
-                otherCache.getOrPut(sharedTile) { error("Other owner's shared tile was evicted") }
+                otherCache.getOrPut(listOf(sharedTile)) { _, _ ->
+                    error("Other owner's shared tile was evicted")
+                }.single()
             )
         } finally {
             clearedCache.clear()
@@ -94,8 +99,9 @@ internal class LayerTileCacheTest {
         val cache = LayerTileCache(owner, 1)
         val firstTile = Tile(0, 0, 1)
         val secondTile = Tile(1, 0, 1)
-        val first = cache.getOrPut(firstTile) { key -> loadedTile(key, firstTile, owner) }
-        val second = cache.getOrPut(secondTile) { key -> loadedTile(key, secondTile, owner) }
+        val (first, second) = cache.getOrPut(listOf(firstTile, secondTile)) { tile, key ->
+            loadedTile(key, tile, owner)
+        }
 
         cache.invalidate()
 

--- a/guides/en-US/guide_tool_settings.txt
+++ b/guides/en-US/guide_tool_settings.txt
@@ -174,6 +174,9 @@ Some tools such as Navigation and Astronomy display error banners at the top of 
 ## Experimental
 Experimental features can be enabled in Settings > Experimental. These features are not ready for general use and may not work as expected.
 
+### Use large tile cache
+By default, each map layer keeps a tile cache sized for the current screen. Enable this setting to let each map layer retain more tiles. This may reduce tile reloading while using maps, but it can significantly increase memory usage when several map layers are enabled.
+
 ### Use legacy file picker
 If the system file picker is not working correctly on your device, enable this setting to use the legacy file picker instead. It might help, but this is just a potential workaround for an upstream issue.
 


### PR DESCRIPTION
Creates a shared tile cache (256 tiles) and a smaller (2x desired tiles) cache per layer. Layers primarily use their cache for rendering the screen and when new tiles are loaded it dumps older tiles to the shared cache. This allows each layer to have a much smaller memory footprint while still being able to cache neighboring or parent tiles.

This also adds an experiment preference for restoring the large tile caches, which can be used for devices where memory is not a concern.

Issue: #3877 
