### PR TITLE
Issues/2767/bubble level angle text

### DIFF
--- a/app/src/androidTest/java/com/kylecorry/trail_sense/tools/level/ToolBubbleLevelTest.kt
+++ b/app/src/androidTest/java/com/kylecorry/trail_sense/tools/level/ToolBubbleLevelTest.kt
@@ -19,6 +19,7 @@ class ToolBubbleLevelTest : ToolTestBase(Tools.BUBBLE_LEVEL) {
                 string(
                     R.string.bubble_level_angles,
                     "\\d+\\.\\d°",
+                    "\\d+\\.\\d°",
                     "\\d+\\.\\d°"
                 )
             )

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/level/ui/BubbleLevel.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/level/ui/BubbleLevel.kt
@@ -155,6 +155,14 @@ class BubbleLevel(context: Context?, attrs: AttributeSet? = null) : CanvasView(c
             bubbleRadius * 2
         )
 
+        // Center bubble label
+        val centerTilt = hypot(xAngle, yAngle).coerceAtMost(90f)
+        val centerLabel = formatter.formatDegrees(centerTilt)
+        fill(textColor)
+        textSize(textSize)
+        textMode(TextMode.Center)
+        text(centerLabel, xBarLeft + barLength / 2f + xPercentCenter, yBarTop + barLength / 2f + yPercentCenter)
+
         // Text
         val xText = formatter.formatDegrees(abs(xAngle))
         val yText = formatter.formatDegrees(abs(yAngle))

--- a/app/src/main/java/com/kylecorry/trail_sense/tools/level/ui/LevelFragment.kt
+++ b/app/src/main/java/com/kylecorry/trail_sense/tools/level/ui/LevelFragment.kt
@@ -10,6 +10,7 @@ import com.kylecorry.trail_sense.databinding.FragmentToolLevelBinding
 import com.kylecorry.trail_sense.shared.FormatService
 import com.kylecorry.trail_sense.shared.sensors.SensorService
 import kotlin.math.abs
+import kotlin.math.hypot
 
 class LevelFragment : BoundFragment<FragmentToolLevelBinding>() {
 
@@ -39,10 +40,13 @@ class LevelFragment : BoundFragment<FragmentToolLevelBinding>() {
         binding.level.xAngle = x
         binding.level.yAngle = y
 
+        val hypotenuse = hypot(x, y).coerceAtMost(90f)
+
         binding.levelTitle.title.text = getString(
             R.string.bubble_level_angles,
             formatService.formatDegrees(abs(x), 1),
-            formatService.formatDegrees(abs(y), 1)
+            formatService.formatDegrees(abs(y), 1),
+            formatService.formatDegrees(hypotenuse, 1)
         )
         return true
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -268,7 +268,6 @@
     <string name="threshold">الحد الأدنى</string>
     <string name="update_gps_override">تحديث تجاوز GPS</string>
     <string name="delete_note_title">حذف الملاحظة؟</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="map_scale_ratio">النسبة</string>
     <string name="map_scale_verbal">لفظي</string>
     <string name="min_temp_calibrated">أدنى درجة حرارة محيطة (معايرة)</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -268,7 +268,7 @@
     <string name="threshold">الحد الأدنى</string>
     <string name="update_gps_override">تحديث تجاوز GPS</string>
     <string name="delete_note_title">حذف الملاحظة؟</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="map_scale_ratio">النسبة</string>
     <string name="map_scale_verbal">لفظي</string>
     <string name="min_temp_calibrated">أدنى درجة حرارة محيطة (معايرة)</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -314,7 +314,6 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Centimetri</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Sadržaj</string>
     <string name="note_title_hint">Naslov</string>
     <string name="tool_notes_title">Napomene</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -314,8 +314,7 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Centimetri</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Sadržaj</string>
     <string name="note_title_hint">Naslov</string>
     <string name="tool_notes_title">Napomene</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -275,8 +275,7 @@
     <string name="metal_detector_disclaimer">Només detecta metalls magnètics (ex. ferro)</string>
     <string name="notes_empty_text">Sense notes</string>
     <string name="contents">Contingut</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="distance_to">Fins a</string>
     <string name="unit_nautical_miles">Milles nàutiques</string>
     <string name="solar_panel_instructions">Col·loqueu el telèfon a la cara del panell solar per començar.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -275,7 +275,6 @@
     <string name="metal_detector_disclaimer">Només detecta metalls magnètics (ex. ferro)</string>
     <string name="notes_empty_text">Sense notes</string>
     <string name="contents">Contingut</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="distance_to">Fins a</string>
     <string name="unit_nautical_miles">Milles nàutiques</string>
     <string name="solar_panel_instructions">Col·loqueu el telèfon a la cara del panell solar per començar.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -408,8 +408,7 @@
     <string name="map_scale_ratio">Poměr</string>
     <string name="min_temp_uncalibrated">Minimální teplota telefonu (nekalibrovaná)</string>
     <string name="note_title_hint">Titulek</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centimetry</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">in</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -408,7 +408,6 @@
     <string name="map_scale_ratio">Poměr</string>
     <string name="min_temp_uncalibrated">Minimální teplota telefonu (nekalibrovaná)</string>
     <string name="note_title_hint">Titulek</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centimetry</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">in</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -628,8 +628,7 @@
     <string name="map_scale_verbal">Verbal</string>
     <string name="waypoint_time_format">%1$s, %2$s</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="pref_backtrack_frequency_title">Backtrack interval</string>
     <string name="location_input_help_title">Understøttede lokationsformater</string>
     <string name="battery_power_ac">Vekselstrøm</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -628,7 +628,6 @@
     <string name="map_scale_verbal">Verbal</string>
     <string name="waypoint_time_format">%1$s, %2$s</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="pref_backtrack_frequency_title">Backtrack interval</string>
     <string name="location_input_help_title">Understøttede lokationsformater</string>
     <string name="battery_power_ac">Vekselstrøm</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -323,7 +323,6 @@
     <string name="coordinate_format_mgrs">MGRS</string>
     <string name="create_beacon">Wegpunkt anlegen</string>
     <string name="charging_wireless">Wird geladen (%s)</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="coordinate_format_utm">UTM</string>
     <string name="precise_temp_c_format">%s °C</string>
     <string name="precise_temp_f_format">%s °F</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -323,8 +323,7 @@
     <string name="coordinate_format_mgrs">MGRS</string>
     <string name="create_beacon">Wegpunkt anlegen</string>
     <string name="charging_wireless">Wird geladen (%s)</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="coordinate_format_utm">UTM</string>
     <string name="precise_temp_c_format">%s °C</string>
     <string name="precise_temp_f_format">%s °F</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -518,8 +518,7 @@
     <string name="import_btn">Εισαγωγή</string>
     <string name="calibrate_new_tide">Βαθμονόμηση σε νέα παλίρροια;</string>
     <string name="gps_searching">Σε αναζήτηση</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="water_purification_step_3">Εκκινήστε το χρονόμετρο</string>
     <string name="gps_signal_lost">Χάθηκε το σήμα GPS</string>
     <string name="delete_waypoint_prompt">Διαγραφή σημείου διαδρομής;</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -518,7 +518,6 @@
     <string name="import_btn">Εισαγωγή</string>
     <string name="calibrate_new_tide">Βαθμονόμηση σε νέα παλίρροια;</string>
     <string name="gps_searching">Σε αναζήτηση</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="water_purification_step_3">Εκκινήστε το χρονόμετρο</string>
     <string name="gps_signal_lost">Χάθηκε το σήμα GPS</string>
     <string name="delete_waypoint_prompt">Διαγραφή σημείου διαδρομής;</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -321,7 +321,6 @@
     <string name="notes_empty_text">Sin notas</string>
     <string name="delete_note_title">¿Eliminar nota\?</string>
     <string name="tool_notes_title">Notas</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="tool_white_noise_title">Ruido Blanco</string>
     <string name="tool_white_noise_summary">Le ayuda a dormir</string>
     <string name="map_scale_ratio">Proporción</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -321,8 +321,7 @@
     <string name="notes_empty_text">Sin notas</string>
     <string name="delete_note_title">¿Eliminar nota\?</string>
     <string name="tool_notes_title">Notas</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="tool_white_noise_title">Ruido Blanco</string>
     <string name="tool_white_noise_summary">Le ayuda a dormir</string>
     <string name="map_scale_ratio">Proporción</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -429,8 +429,7 @@
     <string name="notification_channel_clock_sync_description">Jakinarazpen bat zure erlojua GPSaren orduarekin sinkronizatzeko</string>
     <string name="clock_sync_instructions">Jakinarazpena jasotzean ordu hau ezarri: %s</string>
     <string name="update_gps_override">Eguneratu GPSaren ordezkapena</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="min_temp_uncalibrated">Mugikorraren gutxieneko tenperatura (kalibratu gabea)</string>
     <string name="backtrack_notification_channel_description">Trazatu kokapenaren eguneraketak</string>
     <string name="pref_backtrack_frequency_title">Trazaduraren bitarteak</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -429,7 +429,6 @@
     <string name="notification_channel_clock_sync_description">Jakinarazpen bat zure erlojua GPSaren orduarekin sinkronizatzeko</string>
     <string name="clock_sync_instructions">Jakinarazpena jasotzean ordu hau ezarri: %s</string>
     <string name="update_gps_override">Eguneratu GPSaren ordezkapena</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="min_temp_uncalibrated">Mugikorraren gutxieneko tenperatura (kalibratu gabea)</string>
     <string name="backtrack_notification_channel_description">Trazatu kokapenaren eguneraketak</string>
     <string name="pref_backtrack_frequency_title">Trazaduraren bitarteak</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -428,7 +428,6 @@
     <string name="strobe_warning_title">چراغ چشمک زن</string>
     <string name="clock_waiting_for_gps">در حال به‌روزرسانی زمان از GPS…</string>
     <string name="tool_notes_title">یادداشت</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="delete_note_title">یادداشت حذف شود؟</string>
     <string name="note_title_hint">عنوان</string>
     <string name="pref_backtrack_frequency_title">فاصله بک ترک</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -428,8 +428,7 @@
     <string name="strobe_warning_title">چراغ چشمک زن</string>
     <string name="clock_waiting_for_gps">در حال به‌روزرسانی زمان از GPS…</string>
     <string name="tool_notes_title">یادداشت</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="delete_note_title">یادداشت حذف شود؟</string>
     <string name="note_title_hint">عنوان</string>
     <string name="pref_backtrack_frequency_title">فاصله بک ترک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -919,7 +919,7 @@
     <string name="compass_declination">Eranto</string>
     <string name="tool_category_signaling">Viestitys</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="cirrus">Untuvapilviä</string>
     <string name="imperial_cups">Imperiallista kuppia</string>
     <string name="imperial_pints">Imperiallista tuoppia</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -919,7 +919,6 @@
     <string name="compass_declination">Eranto</string>
     <string name="tool_category_signaling">Viestitys</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="cirrus">Untuvapilviä</string>
     <string name="imperial_cups">Imperiallista kuppia</string>
     <string name="imperial_pints">Imperiallista tuoppia</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -254,8 +254,7 @@
     <string name="water_boil_timer_done_title">L\'eau ne bout plus</string>
     <string name="unit_inches">Pouces</string>
     <string name="unit_centimeters">Centimètres</string>
-    <string name="bubble_level_angles">X : %1$s
-\nY : %2$s</string>
+    <string name="bubble_level_angles">X : %1$s\nY : %2$s\nAngle: %3$s</string>
     <string name="contents">Contenu</string>
     <string name="note_title_hint">Titre</string>
     <string name="tool_notes_title">Notes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -254,7 +254,6 @@
     <string name="water_boil_timer_done_title">L\'eau ne bout plus</string>
     <string name="unit_inches">Pouces</string>
     <string name="unit_centimeters">Centimètres</string>
-    <string name="bubble_level_angles">X : %1$s\nY : %2$s\nAngle: %3$s</string>
     <string name="contents">Contenu</string>
     <string name="note_title_hint">Titre</string>
     <string name="tool_notes_title">Notes</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -331,7 +331,6 @@
     <string name="tool_notes_title">Notas</string>
     <string name="note_title_hint">Título</string>
     <string name="contents">Contidos</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centímetros</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">polgadas</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -331,7 +331,7 @@
     <string name="tool_notes_title">Notas</string>
     <string name="note_title_hint">Título</string>
     <string name="contents">Contidos</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centímetros</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">polgadas</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -643,8 +643,7 @@
     <string name="threshold">Határérték</string>
     <string name="tool_metal_detector_title">Fémérzékelő</string>
     <string name="contents">Tartalom</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_inches">Inch</string>
     <string name="metal_detector_disclaimer">Csak mágneses fémeket érzékel (pl. vas)</string>
     <string name="update_gps_override">GPS felülírás frissítése</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -643,7 +643,6 @@
     <string name="threshold">Határérték</string>
     <string name="tool_metal_detector_title">Fémérzékelő</string>
     <string name="contents">Tartalom</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_inches">Inch</string>
     <string name="metal_detector_disclaimer">Csak mágneses fémeket érzékel (pl. vas)</string>
     <string name="update_gps_override">GPS felülírás frissítése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -162,7 +162,6 @@
     <string name="tool_metal_detector_title">Detektor Logam</string>
     <string name="metal_detector_disclaimer">Hanya mendeteksi logam magnetik (mis. besi)</string>
     <string name="tool_notes_title">Catatan</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Sentimeter</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">in</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -162,8 +162,7 @@
     <string name="tool_metal_detector_title">Detektor Logam</string>
     <string name="metal_detector_disclaimer">Hanya mendeteksi logam magnetik (mis. besi)</string>
     <string name="tool_notes_title">Catatan</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Sentimeter</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">in</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -466,7 +466,6 @@
     <string name="current_format">%s mA</string>
     <string name="pref_privacy_policy_title">Informativa sulla privacy</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="waypoint_time_format">%1$s, %2$s</string>
     <string name="battery_power_ac">AC</string>
     <string name="battery_power_wireless">Senza fili</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -466,8 +466,7 @@
     <string name="current_format">%s mA</string>
     <string name="pref_privacy_policy_title">Informativa sulla privacy</string>
     <string name="magnetic_field_format_precise">%s uT</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="waypoint_time_format">%1$s, %2$s</string>
     <string name="battery_power_ac">AC</string>
     <string name="battery_power_wireless">Senza fili</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -325,7 +325,7 @@
     <string name="tool_lightning_title">מרחק מכת ברק</string>
     <string name="tool_battery_title">סוללה</string>
     <string name="clock_sync_instructions">הגדר את השעה ל- %s כאשר ההודעה מגיעה</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters_abbreviation">ס\"מ</string>
     <string name="map_scale_title">קנה מידה של מפה</string>
     <string name="map_scale_ratio">יחס</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -325,7 +325,6 @@
     <string name="tool_lightning_title">מרחק מכת ברק</string>
     <string name="tool_battery_title">סוללה</string>
     <string name="clock_sync_instructions">הגדר את השעה ל- %s כאשר ההודעה מגיעה</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters_abbreviation">ס\"מ</string>
     <string name="map_scale_title">קנה מידה של מפה</string>
     <string name="map_scale_ratio">יחס</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -258,7 +258,6 @@
     <string name="notes_empty_text">Ingen notater</string>
     <string name="delete_note_title">Slette notat\?</string>
     <string name="unit_centimeters">Centimeter</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Innhold</string>
     <string name="note_title_hint">Tittel</string>
     <string name="tool_notes_title">Notater</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -258,8 +258,7 @@
     <string name="notes_empty_text">Ingen notater</string>
     <string name="delete_note_title">Slette notat\?</string>
     <string name="unit_centimeters">Centimeter</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Innhold</string>
     <string name="note_title_hint">Tittel</string>
     <string name="tool_notes_title">Notater</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -329,7 +329,6 @@
     <string name="map_distance">Kaart: %s</string>
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Inhoud</string>
     <string name="note_title_hint">Titel</string>
     <string name="tool_notes_title">Notities</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -329,8 +329,7 @@
     <string name="map_distance">Kaart: %s</string>
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Inhoud</string>
     <string name="note_title_hint">Titel</string>
     <string name="tool_notes_title">Notities</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -241,7 +241,7 @@
     <string name="notes_empty_text">Brak notatek</string>
     <string name="delete_note_title">Usunąć notatkę\?</string>
     <string name="tool_notes_title">Notatki</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centymetry</string>
     <string name="unit_inches">Cale</string>
     <string name="map_distance">Mapa: %s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -241,7 +241,6 @@
     <string name="notes_empty_text">Brak notatek</string>
     <string name="delete_note_title">Usunąć notatkę\?</string>
     <string name="tool_notes_title">Notatki</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centymetry</string>
     <string name="unit_inches">Cale</string>
     <string name="map_distance">Mapa: %s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -386,7 +386,6 @@
     <string name="map_scale_verbal">Verbal</string>
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="location_override_updated">Local simulado atualizado</string>
     <string name="update_gps_override">Atualizar GPS simulado</string>
     <string name="coordinate_format_mgrs">MGRS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -386,8 +386,7 @@
     <string name="map_scale_verbal">Verbal</string>
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="location_override_updated">Local simulado atualizado</string>
     <string name="update_gps_override">Atualizar GPS simulado</string>
     <string name="coordinate_format_mgrs">MGRS</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -84,7 +84,6 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Centímetros</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Conteúdos</string>
     <string name="note_title_hint">Título</string>
     <string name="tool_notes_title">Anotações</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -84,8 +84,7 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Centímetros</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Conteúdos</string>
     <string name="note_title_hint">Título</string>
     <string name="tool_notes_title">Anotações</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -297,8 +297,7 @@
     <string name="map_distance">Карта: %s</string>
     <string name="unit_inches">Дюймы</string>
     <string name="unit_centimeters">Сантиметры</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Содержание</string>
     <string name="note_title_hint">Название</string>
     <string name="tool_notes_title">Заметки</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -297,7 +297,6 @@
     <string name="map_distance">Карта: %s</string>
     <string name="unit_inches">Дюймы</string>
     <string name="unit_centimeters">Сантиметры</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">Содержание</string>
     <string name="note_title_hint">Название</string>
     <string name="tool_notes_title">Заметки</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -624,7 +624,6 @@
     <string name="tool_notes_title">குறிப்புகள்</string>
     <string name="note_title_hint">தலைப்பு</string>
     <string name="contents">உள்ளடக்கங்கள்</string>
-    <string name="bubble_level_angles">எக்ச்: %1$s\n Y: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">சென்டிமீட்டர்</string>
     <string name="unit_centimeters_abbreviation">முதல்வர்</string>
     <string name="unit_inches_abbreviation">இல்</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -624,7 +624,7 @@
     <string name="tool_notes_title">குறிப்புகள்</string>
     <string name="note_title_hint">தலைப்பு</string>
     <string name="contents">உள்ளடக்கங்கள்</string>
-    <string name="bubble_level_angles">எக்ச்: %1$s\n Y: %2$s</string>
+    <string name="bubble_level_angles">எக்ச்: %1$s\n Y: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">சென்டிமீட்டர்</string>
     <string name="unit_centimeters_abbreviation">முதல்வர்</string>
     <string name="unit_inches_abbreviation">இல்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -110,7 +110,6 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Santimetre</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">İçerikler</string>
     <string name="note_title_hint">Başlık</string>
     <string name="tool_notes_title">Notlar</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -110,8 +110,7 @@
     <string name="unit_inches_abbreviation">in</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_centimeters">Santimetre</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">İçerikler</string>
     <string name="note_title_hint">Başlık</string>
     <string name="tool_notes_title">Notlar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -365,8 +365,7 @@
     <string name="unit_inches_abbreviation">дюйм</string>
     <string name="unit_centimeters_abbreviation">см</string>
     <string name="unit_centimeters">Сантиметри</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="note_title_hint">Заголовок</string>
     <string name="tool_notes_title">Примітки</string>
     <string name="delete_note_title">Видалити примітку\?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -365,7 +365,6 @@
     <string name="unit_inches_abbreviation">дюйм</string>
     <string name="unit_centimeters_abbreviation">см</string>
     <string name="unit_centimeters">Сантиметри</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="note_title_hint">Заголовок</string>
     <string name="tool_notes_title">Примітки</string>
     <string name="delete_note_title">Видалити примітку\?</string>

--- a/app/src/main/res/values-yue/strings.xml
+++ b/app/src/main/res/values-yue/strings.xml
@@ -678,8 +678,7 @@
     <string name="weather_monitor">氣象監測</string>
     <string name="battery_history">電量紀錄：過去嗰 %s</string>
     <string name="tool_bubble_level_summary">睇下個面係咪平</string>
-    <string name="bubble_level_angles">橫：%1$s
-\n縱：%2$s</string>
+    <string name="bubble_level_angles">橫：%1$s\n縱：%2$s\nAngle: %3$s</string>
     <string name="humidity">濕度</string>
     <string name="elevation_history">海拔紀錄</string>
     <string name="elevation_history_length">海拔紀錄幾耐</string>

--- a/app/src/main/res/values-yue/strings.xml
+++ b/app/src/main/res/values-yue/strings.xml
@@ -678,7 +678,6 @@
     <string name="weather_monitor">氣象監測</string>
     <string name="battery_history">電量紀錄：過去嗰 %s</string>
     <string name="tool_bubble_level_summary">睇下個面係咪平</string>
-    <string name="bubble_level_angles">橫：%1$s\n縱：%2$s\nAngle: %3$s</string>
     <string name="humidity">濕度</string>
     <string name="elevation_history">海拔紀錄</string>
     <string name="elevation_history_length">海拔紀錄幾耐</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -181,7 +181,6 @@
     <string name="map_scale_ratio">比例</string>
     <string name="tool_white_noise_summary">幫助你入睡</string>
     <string name="tool_white_noise_title">白噪聲</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="delete_note_title">刪除筆記？</string>
     <string name="notes_empty_text">沒有筆記</string>
     <string name="metal_detector_disclaimer">只探測可磁化金屬（例如：鐵）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -181,8 +181,7 @@
     <string name="map_scale_ratio">比例</string>
     <string name="tool_white_noise_summary">幫助你入睡</string>
     <string name="tool_white_noise_title">白噪聲</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="delete_note_title">刪除筆記？</string>
     <string name="notes_empty_text">沒有筆記</string>
     <string name="metal_detector_disclaimer">只探測可磁化金屬（例如：鐵）</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -283,7 +283,6 @@
     <string name="map_distance">地图：%s</string>
     <string name="unit_inches">英寸</string>
     <string name="unit_centimeters">厘米</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">内容</string>
     <string name="note_title_hint">标题</string>
     <string name="tool_notes_title">笔记</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -283,8 +283,7 @@
     <string name="map_distance">地图：%s</string>
     <string name="unit_inches">英寸</string>
     <string name="unit_centimeters">厘米</string>
-    <string name="bubble_level_angles">X: %1$s
-\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="contents">内容</string>
     <string name="note_title_hint">标题</string>
     <string name="tool_notes_title">笔记</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,7 +510,7 @@
     <string name="tool_notes_title">Notes</string>
     <string name="note_title_hint">Title</string>
     <string name="contents">Contents</string>
-    <string name="bubble_level_angles">X: %1$s\nY: %2$s</string>
+    <string name="bubble_level_angles">X: %1$s\nY: %2$s\nAngle: %3$s</string>
     <string name="unit_centimeters">Centimeters</string>
     <string name="unit_centimeters_abbreviation">cm</string>
     <string name="unit_inches_abbreviation">in</string>


### PR DESCRIPTION
I can't find my original request anymore but Kyle opened it as a feature enhancement here https://github.com/kylecorry31/Trail-Sense/issues/2767

The overall idea is that the bubble level is actually the ideal tool to tell you the angle of any surface but it doesn't actually. It internally calculates the angle to draw the bubble-circle but it doesn't actually report the angle in the label of the bubble circle. If you put your phone on a surface, no matter the orientation of the top/side of the phone, the bubble level itself should read a consistent angle that the plane of the phone is sitting on; a combination of the x/y. 

There was discussion whether to call it R for radius, theta, or what but Kyle suggested "Angle" because that's less math-y. So that's what I called it and put it into the translation files as. But I left it as English, maybe the wrong decision.

<img width="417" height="865" alt="image" src="https://github.com/user-attachments/assets/7eb9cde4-75e7-4f91-97f7-1826ad780e3d" />
<img width="422" height="802" alt="image" src="https://github.com/user-attachments/assets/5957ee8c-1d35-4b75-b17b-328fc84cc349" />
<img width="421" height="813" alt="image" src="https://github.com/user-attachments/assets/5b0ef66f-899d-4165-99c9-331bde42361f" />

You can see here all the pieces, the angle listed, as well as a demonstration of an x=0 -vs- y=0 -vs- actual plane calculated.


Issue: #2767

## Checklist

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/kylecorry31/Trail-Sense/blob/main/CONTRIBUTING.md) guide and confirm that I am following it
- [x] I have tested these changes on an Android device or emulator
